### PR TITLE
Add convenience method to MediaFormatBuilder and fix unmodifiability of file extensions in MediaFormat

### DIFF
--- a/media/changes.xml
+++ b/media/changes.xml
@@ -23,6 +23,15 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
+    <release version="0.9.1" date="not released">
+      <action type="add" dev="bdang">
+        Add a create() method for MediaFormatBuilder which can consume an existing media format and copy its data to the builder.
+      </action>
+      <action type="fix" dev="bdang">
+        Make the extensions array of an existing MediaFormat unmodifiable.
+      </action>
+    </release>
+
     <release version="0.9.0" date="2015-09-09">
       <action type="add" dev="sseifert" issue="WHAN-13">
         Optional included AEM-generated asset thumbnails for media handling.

--- a/media/src/main/java/io/wcm/handler/media/format/MediaFormat.java
+++ b/media/src/main/java/io/wcm/handler/media/format/MediaFormat.java
@@ -231,7 +231,7 @@ public final class MediaFormat implements Comparable<MediaFormat> {
    * @return Allowed file extensions
    */
   public String[] getExtensions() {
-    return this.extensions;
+    return this.extensions.clone();
   }
 
   /**

--- a/media/src/main/java/io/wcm/handler/media/format/MediaFormatBuilder.java
+++ b/media/src/main/java/io/wcm/handler/media/format/MediaFormatBuilder.java
@@ -72,12 +72,39 @@ public final class MediaFormatBuilder {
    * Create a new media format builder.
    * @param name Media format name. Only characters, numbers, hyphen and underline are allowed.
    * @param applicationId Application id
-   * @return Media foramt builder
+   * @return Media format builder
    */
   public static MediaFormatBuilder create(String name, String applicationId) {
     return new MediaFormatBuilder()
-    .name(name)
-    .applicationId(applicationId);
+        .name(name)
+        .applicationId(applicationId);
+  }
+
+  /**
+   * Create a new media format builder based on an existing media format.
+   * @param mediaFormat Media format from which data is copied
+   * @return Media format builder
+   */
+  public static MediaFormatBuilder create(MediaFormat mediaFormat) {
+    return new MediaFormatBuilder()
+        .name(mediaFormat.getName())
+        .applicationId(mediaFormat.getApplicationId())
+        .label(mediaFormat.getLabel())
+        .description(mediaFormat.getDescription())
+        .width(mediaFormat.getWidth())
+        .minWidth(mediaFormat.getMinWidth())
+        .maxWidth(mediaFormat.getMaxWidth())
+        .height(mediaFormat.getHeight())
+        .minHeight(mediaFormat.getMinHeight())
+        .maxHeight(mediaFormat.getMaxHeight())
+        .ratio(mediaFormat.getRatio())
+        .ratio(mediaFormat.getRatioWidth(), mediaFormat.getRatioHeight())
+        .fileSizeMax(mediaFormat.getFileSizeMax())
+        .extensions(mediaFormat.getExtensions())
+        .renditionGroup(mediaFormat.getRenditionGroup())
+        .internal(mediaFormat.isInternal())
+        .ranking((int)mediaFormat.getRanking())
+        .properties(mediaFormat.getProperties());
   }
 
   /**
@@ -245,7 +272,7 @@ public final class MediaFormatBuilder {
    * @return this
    */
   public MediaFormatBuilder extensions(String... value) {
-    this.extensions = value;
+    this.extensions = value.clone();
     return this;
   }
 

--- a/media/src/main/java/io/wcm/handler/media/format/package-info.java
+++ b/media/src/main/java/io/wcm/handler/media/format/package-info.java
@@ -20,5 +20,5 @@
 /**
  * Media format management.
  */
-@org.osgi.annotation.versioning.Version("0.6.0")
+@org.osgi.annotation.versioning.Version("0.7.0")
 package io.wcm.handler.media.format;


### PR DESCRIPTION
Hello,

there are two concerns in this pull request.

# MediaFormatBuilder

I added a new create method, in order to initialize a new builder which has set all data from an existing media format. This can be usefull if you want to add something to a media format in the media handler's preprocessing step. For example setting special properties which are evaluated in an own media markup builder impl.

Are there arguments against such a create() method? I also backed it up by jUnit tests. So if you add a new field and getter and forget about updating the new create() method, a jUnit test will fail.

# MediaFormat

In my understanding you cannot modify anything in an existing media format object. 

In the current impl you can modify the internal file extensions array. Either by `mediaFormat.getExtensions()[0] = "I changed it"` or by
```
    String[] extensionsSource = {
        "png"
    };

    MediaFormat mf = MediaFormatBuilder.create("name", "/app_id")
        .extensions(extensionsSource)
        .build();

    extensionsSource[0] = "I changed it";
```