### PR TITLE
Make SiteRoot adaptable from Resource

### DIFF
--- a/url/changes.xml
+++ b/url/changes.xml
@@ -23,6 +23,12 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
+    <release version="1.1.2" date="not released">
+      <action type="add" dev="amuthmann">
+        Make SiteRoot adaptable from Resource
+      </action>
+    </release>
+    
     <release version="1.1.0" date="2017-06-02">
       <action type="add" dev="sseifert">
         Introduce SiteRootDetector service, and use it by default in DefaultUrlHandlerConfig.

--- a/url/src/main/java/io/wcm/handler/url/ui/SiteRoot.java
+++ b/url/src/main/java/io/wcm/handler/url/ui/SiteRoot.java
@@ -38,7 +38,7 @@ import io.wcm.sling.models.annotations.AemObject;
  * Model for detecting site root pages.
  */
 @ProviderType
-@Model(adaptables = SlingHttpServletRequest.class)
+@Model(adaptables = {SlingHttpServletRequest.class, Resource.class})
 public final class SiteRoot {
 
   private Page siteRootPage;

--- a/url/src/main/java/io/wcm/handler/url/ui/package-info.java
+++ b/url/src/main/java/io/wcm/handler/url/ui/package-info.java
@@ -20,5 +20,5 @@
 /**
  * Sling model classes for UI views.
  */
-@org.osgi.annotation.versioning.Version("1.0.0")
+@org.osgi.annotation.versioning.Version("1.0.1")
 package io.wcm.handler.url.ui;

--- a/url/src/test/java/io/wcm/handler/url/ui/SiteRootTest.java
+++ b/url/src/test/java/io/wcm/handler/url/ui/SiteRootTest.java
@@ -45,6 +45,10 @@ public class SiteRootTest {
   public void testGetRootPath() {
     SiteRoot underTest = context.request().adaptTo(SiteRoot.class);
     assertEquals("/content/unittest/de_test/brand/de", underTest.getRootPath());
+
+    // check that SiteRoot also works with resources
+    underTest = context.currentResource().adaptTo(SiteRoot.class);
+    assertEquals("/content/unittest/de_test/brand/de", underTest.getRootPath());
   }
 
   @Test
@@ -57,6 +61,10 @@ public class SiteRootTest {
   @Test
   public void testGetRootPage() {
     SiteRoot underTest = context.request().adaptTo(SiteRoot.class);
+    assertEquals("/content/unittest/de_test/brand/de", underTest.getRootPage().getPath());
+
+    // check that SiteRoot also works with resources
+    underTest = context.currentResource().adaptTo(SiteRoot.class);
     assertEquals("/content/unittest/de_test/brand/de", underTest.getRootPage().getPath());
   }
 


### PR DESCRIPTION
Currently it's not possible to use SiteRoot from a Model that is adaptable from a Resource (e.g. when using the @ChildResource annotation).

This PR add this possibility.

Note: I'm not sure, if all tests should be replicated, I added two modifications to prove, that the change works. 