### PR TITLE
Synthetic link resources: Allow to specify a path

### DIFF
--- a/link/changes.xml
+++ b/link/changes.xml
@@ -23,6 +23,13 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
+    <release version="1.2.6" date="not released">
+      <action type="update" dev="sseifert">
+        Synthetic link resources: Allow to specify a path for the synthetic resource, and deprecate the signatures without path.
+        Without a valid application-specific path the wrong handler configuration may be looked up via context-aware services.
+      </action>
+    </release>
+
     <release version="1.2.4" date="2019-06-06">
       <action type="fix" dev="sseifert">
         Media link path field: Fix NPE when content resource is null.

--- a/link/src/main/java/io/wcm/handler/link/SyntheticLinkResource.java
+++ b/link/src/main/java/io/wcm/handler/link/SyntheticLinkResource.java
@@ -43,19 +43,48 @@ public final class SyntheticLinkResource extends SyntheticResource {
   /**
    * Instantiate resource with static path/resource type
    * @param resourceResolver Resource resolver
+   * @param path Resource path. Can be a non-existing path, but the path should be located somewhere within the
+   *          applications content paths to make sure the handler configuration looked up via context-aware services
+   *          is the expected one.
    */
+  public SyntheticLinkResource(@NotNull ResourceResolver resourceResolver,
+      @NotNull String path) {
+    this(resourceResolver, path, new HashMap<String, Object>());
+  }
+
+  /**
+   * Instantiate resource with static path/resource type
+   * @param resourceResolver Resource resolver
+   * @param path Resource path. Can be a non-existing path, but the path should be located somewhere within the
+   *          applications content paths to make sure the handler configuration looked up via context-aware services
+   *          is the expected one.
+   * @param properties Properties for resource
+   */
+  public SyntheticLinkResource(@NotNull ResourceResolver resourceResolver,
+      @NotNull String path, @NotNull Map<String, Object> properties) {
+    super(resourceResolver, path, PATH);
+    this.properties = new ValueMapDecorator(properties);
+  }
+
+  /**
+   * Instantiate resource with static path/resource type
+   * @param resourceResolver Resource resolver
+   * @deprecated Please use {@link #SyntheticLinkResource(ResourceResolver, String)}
+   */
+  @Deprecated
   public SyntheticLinkResource(@NotNull ResourceResolver resourceResolver) {
-    this(resourceResolver, new HashMap<String, Object>());
+    this(resourceResolver, PATH);
   }
 
   /**
    * Instantiate resource with static path/resource type
    * @param resourceResolver Resource resolver
    * @param properties Properties for resource
+   * @deprecated Please use {@link #SyntheticLinkResource(ResourceResolver, String, Map)}
    */
+  @Deprecated
   public SyntheticLinkResource(@NotNull ResourceResolver resourceResolver, @NotNull Map<String, Object> properties) {
-    super(resourceResolver, PATH, PATH);
-    this.properties = new ValueMapDecorator(properties);
+    this(resourceResolver, PATH, properties);
   }
 
   @Override

--- a/link/src/main/java/io/wcm/handler/link/package-info.java
+++ b/link/src/main/java/io/wcm/handler/link/package-info.java
@@ -20,5 +20,5 @@
 /**
  * Link Handler API.
  */
-@org.osgi.annotation.versioning.Version("1.1")
+@org.osgi.annotation.versioning.Version("1.2")
 package io.wcm.handler.link;

--- a/link/src/main/java/io/wcm/handler/link/type/ExternalLinkType.java
+++ b/link/src/main/java/io/wcm/handler/link/type/ExternalLinkType.java
@@ -107,9 +107,28 @@ public final class ExternalLinkType extends LinkType {
   /**
    * Get synthetic link resource for this link type.
    * @param resourceResolver Resource resolver
+   * @param path Resource path. Can be a non-existing path, but the path should be located somewhere within the
+   *          applications content paths to make sure the handler configuration looked up via context-aware services
+   *          is the expected one.
    * @param url Link URL
    * @return Synthetic link resource
    */
+  public static @NotNull Resource getSyntheticLinkResource(@NotNull ResourceResolver resourceResolver,
+      @NotNull String path, @NotNull String url) {
+    Map<String, Object> map = new HashMap<>();
+    map.put(LinkNameConstants.PN_LINK_TYPE, ID);
+    map.put(LinkNameConstants.PN_LINK_EXTERNAL_REF, url);
+    return new SyntheticLinkResource(resourceResolver, path, map);
+  }
+
+  /**
+   * Get synthetic link resource for this link type.
+   * @param resourceResolver Resource resolver
+   * @param url Link URL
+   * @return Synthetic link resource
+   * @deprecated Please use {@link #getSyntheticLinkResource(ResourceResolver, String, String)}
+   */
+  @Deprecated
   public static @NotNull Resource getSyntheticLinkResource(@NotNull ResourceResolver resourceResolver, @NotNull String url) {
     Map<String, Object> map = new HashMap<>();
     map.put(LinkNameConstants.PN_LINK_TYPE, ID);

--- a/link/src/main/java/io/wcm/handler/link/type/InternalCrossContextLinkType.java
+++ b/link/src/main/java/io/wcm/handler/link/type/InternalCrossContextLinkType.java
@@ -110,9 +110,28 @@ public final class InternalCrossContextLinkType extends LinkType {
   /**
    * Get synthetic link resource for this link type.
    * @param resourceResolver Resource resolver
+   * @param path Resource path. Can be a non-existing path, but the path should be located somewhere within the
+   *          applications content paths to make sure the handler configuration looked up via context-aware services
+   *          is the expected one.
    * @param pageRef Path to target page
    * @return Synthetic link resource
    */
+  public static @NotNull Resource getSyntheticLinkResource(@NotNull ResourceResolver resourceResolver,
+      @NotNull String path, @NotNull String pageRef) {
+    Map<String, Object> map = new HashMap<>();
+    map.put(LinkNameConstants.PN_LINK_TYPE, ID);
+    map.put(LinkNameConstants.PN_LINK_CROSSCONTEXT_CONTENT_REF, pageRef);
+    return new SyntheticLinkResource(resourceResolver, path, map);
+  }
+
+  /**
+   * Get synthetic link resource for this link type.
+   * @param resourceResolver Resource resolver
+   * @param pageRef Path to target page
+   * @return Synthetic link resource
+   * @deprecated Please use {@link #getSyntheticLinkResource(ResourceResolver, String, String)}
+   */
+  @Deprecated
   public static @NotNull Resource getSyntheticLinkResource(@NotNull ResourceResolver resourceResolver, @NotNull String pageRef) {
     Map<String, Object> map = new HashMap<>();
     map.put(LinkNameConstants.PN_LINK_TYPE, ID);

--- a/link/src/main/java/io/wcm/handler/link/type/InternalCrossScopeLinkType.java
+++ b/link/src/main/java/io/wcm/handler/link/type/InternalCrossScopeLinkType.java
@@ -107,9 +107,28 @@ public final class InternalCrossScopeLinkType extends LinkType {
   /**
    * Get synthetic link resource for this link type.
    * @param resourceResolver Resource resolver
+   * @param path Resource path. Can be a non-existing path, but the path should be located somewhere within the
+   *          applications content paths to make sure the handler configuration looked up via context-aware services
+   *          is the expected one.
    * @param pageRef Path to target page
    * @return Synthetic link resource
    */
+  public static @NotNull Resource getSyntheticLinkResource(@NotNull ResourceResolver resourceResolver,
+      @NotNull String path, @NotNull String pageRef) {
+    Map<String, Object> map = new HashMap<>();
+    map.put(LinkNameConstants.PN_LINK_TYPE, ID);
+    map.put(LinkNameConstants.PN_LINK_CONTENT_REF, pageRef);
+    return new SyntheticLinkResource(resourceResolver, path, map);
+  }
+
+  /**
+   * Get synthetic link resource for this link type.
+   * @param resourceResolver Resource resolver
+   * @param pageRef Path to target page
+   * @return Synthetic link resource
+   * @deprecated Please use {@link #getSyntheticLinkResource(ResourceResolver, String, String)}
+   */
+  @Deprecated
   public static @NotNull Resource getSyntheticLinkResource(@NotNull ResourceResolver resourceResolver, @NotNull String pageRef) {
     Map<String, Object> map = new HashMap<>();
     map.put(LinkNameConstants.PN_LINK_TYPE, ID);

--- a/link/src/main/java/io/wcm/handler/link/type/InternalLinkType.java
+++ b/link/src/main/java/io/wcm/handler/link/type/InternalLinkType.java
@@ -112,9 +112,28 @@ public final class InternalLinkType extends LinkType {
   /**
    * Get synthetic link resource for this link type.
    * @param resourceResolver Resource resolver
+   * @param path Resource path. Can be a non-existing path, but the path should be located somewhere within the
+   *          applications content paths to make sure the handler configuration looked up via context-aware services
+   *          is the expected one.
    * @param pageRef Path to target page
    * @return Synthetic link resource
    */
+  public static @NotNull Resource getSyntheticLinkResource(@NotNull ResourceResolver resourceResolver,
+      @NotNull String path, @NotNull String pageRef) {
+    Map<String, Object> map = new HashMap<>();
+    map.put(LinkNameConstants.PN_LINK_TYPE, ID);
+    map.put(LinkNameConstants.PN_LINK_CONTENT_REF, pageRef);
+    return new SyntheticLinkResource(resourceResolver, path, map);
+  }
+
+  /**
+   * Get synthetic link resource for this link type.
+   * @param resourceResolver Resource resolver
+   * @param pageRef Path to target page
+   * @return Synthetic link resource
+   * @deprecated Please use {@link #getSyntheticLinkResource(ResourceResolver, String, String)}
+   */
+  @Deprecated
   public static @NotNull Resource getSyntheticLinkResource(@NotNull ResourceResolver resourceResolver, @NotNull String pageRef) {
     Map<String, Object> map = new HashMap<>();
     map.put(LinkNameConstants.PN_LINK_TYPE, ID);

--- a/link/src/main/java/io/wcm/handler/link/type/MediaLinkType.java
+++ b/link/src/main/java/io/wcm/handler/link/type/MediaLinkType.java
@@ -134,9 +134,28 @@ public final class MediaLinkType extends LinkType {
   /**
    * Get synthetic link resource for this link type.
    * @param resourceResolver Resource resolver
+   * @param path Resource path. Can be a non-existing path, but the path should be located somewhere within the
+   *          applications content paths to make sure the handler configuration looked up via context-aware services
+   *          is the expected one.
    * @param mediaRef Media asset reference
    * @return Synthetic link resource
    */
+  public static @NotNull Resource getSyntheticLinkResource(@NotNull ResourceResolver resourceResolver,
+      @NotNull String path, @NotNull String mediaRef) {
+    Map<String, Object> map = new HashMap<>();
+    map.put(LinkNameConstants.PN_LINK_TYPE, ID);
+    map.put(LinkNameConstants.PN_LINK_MEDIA_REF, mediaRef);
+    return new SyntheticLinkResource(resourceResolver, path, map);
+  }
+
+  /**
+   * Get synthetic link resource for this link type.
+   * @param resourceResolver Resource resolver
+   * @param mediaRef Media asset reference
+   * @return Synthetic link resource
+   * @deprecated Please use {@link #getSyntheticLinkResource(ResourceResolver, String, String)}
+   */
+  @Deprecated
   public static @NotNull Resource getSyntheticLinkResource(@NotNull ResourceResolver resourceResolver, @NotNull String mediaRef) {
     Map<String, Object> map = new HashMap<>();
     map.put(LinkNameConstants.PN_LINK_TYPE, ID);

--- a/link/src/main/java/io/wcm/handler/link/type/package-info.java
+++ b/link/src/main/java/io/wcm/handler/link/type/package-info.java
@@ -20,5 +20,5 @@
 /**
  * Default link type implementations.
  */
-@org.osgi.annotation.versioning.Version("1.2")
+@org.osgi.annotation.versioning.Version("1.3")
 package io.wcm.handler.link.type;

--- a/link/src/test/java/io/wcm/handler/link/SyntheticLinkResourceTest.java
+++ b/link/src/test/java/io/wcm/handler/link/SyntheticLinkResourceTest.java
@@ -43,7 +43,7 @@ class SyntheticLinkResourceTest {
 
   @Test
   void testSimpleConstructor() {
-    Resource underTest = new SyntheticLinkResource(resourceResolver);
+    Resource underTest = new SyntheticLinkResource(resourceResolver, "/content/dummy-path");
     ValueMap props = underTest.getValueMap();
     assertTrue(props.isEmpty());
   }
@@ -51,13 +51,38 @@ class SyntheticLinkResourceTest {
   @Test
   void testWithMap() {
     ValueMap givenProps = ImmutableValueMap.of("prop1", "value1");
-    Resource underTest = new SyntheticLinkResource(resourceResolver, givenProps);
+    Resource underTest = new SyntheticLinkResource(resourceResolver, "/content/dummy-path", givenProps);
     ValueMap props = underTest.getValueMap();
     assertEquals(givenProps, ImmutableValueMap.copyOf(props));
   }
 
   @Test
   void testAdaptTo() {
+    Resource underTest = new SyntheticLinkResource(resourceResolver, "/content/dummy-path");
+    Page page = underTest.adaptTo(Page.class);
+    assertNull(page);
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  void testSimpleConstructor_Deprecated() {
+    Resource underTest = new SyntheticLinkResource(resourceResolver);
+    ValueMap props = underTest.getValueMap();
+    assertTrue(props.isEmpty());
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  void testWithMap_Deprecated() {
+    ValueMap givenProps = ImmutableValueMap.of("prop1", "value1");
+    Resource underTest = new SyntheticLinkResource(resourceResolver, givenProps);
+    ValueMap props = underTest.getValueMap();
+    assertEquals(givenProps, ImmutableValueMap.copyOf(props));
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  void testAdaptTo_Deprecated() {
     Resource underTest = new SyntheticLinkResource(resourceResolver);
     Page page = underTest.adaptTo(Page.class);
     assertNull(page);

--- a/link/src/test/java/io/wcm/handler/link/impl/LinkHandlerImplTest.java
+++ b/link/src/test/java/io/wcm/handler/link/impl/LinkHandlerImplTest.java
@@ -62,6 +62,7 @@ class LinkHandlerImplTest {
   static final String APP_ID = "linkHandlerImplTestApp";
 
   final AemContext context = AppAemContext.newAemContext(new AemContextCallback() {
+
     @Override
     public void execute(AemContext callbackContext) {
       callbackContext.registerService(LinkHandlerConfig.class, new TestLinkHandlerConfig(),
@@ -82,10 +83,11 @@ class LinkHandlerImplTest {
 
     // test pipelining and resolve link
     SyntheticLinkResource linkResource = new SyntheticLinkResource(context.resourceResolver(),
+        "/content/dummy-path",
         ImmutableValueMap.builder()
-        .put(LinkNameConstants.PN_LINK_TYPE, "dummy")
-        .put("dummyLinkRef", "/path1")
-        .build());
+            .put(LinkNameConstants.PN_LINK_TYPE, "dummy")
+            .put("dummyLinkRef", "/path1")
+            .build());
     LinkRequest linkRequest = new LinkRequest(linkResource, null, new LinkArgs().urlMode(UrlModes.DEFAULT));
     Link link = linkHandler.get(linkRequest).build();
 
@@ -130,6 +132,7 @@ class LinkHandlerImplTest {
       SlingHttpServletRequest.class, Resource.class
   })
   public static class TestLinkPreProcessor implements LinkProcessor {
+
     @Override
     public Link process(Link link) {
       LinkRequest linkRequest = link.getLinkRequest();
@@ -140,8 +143,7 @@ class LinkHandlerImplTest {
       LinkRequest newLinkRequest = new LinkRequest(
           linkRequest.getResource(),
           linkRequest.getPage(),
-          new LinkArgs().urlMode(UrlModes.FULL_URL)
-          );
+          new LinkArgs().urlMode(UrlModes.FULL_URL));
       newLinkRequest.getResourceProperties().put("dummyLinkRef", contentRef);
       link.setLinkRequest(newLinkRequest);
       return link;
@@ -181,6 +183,7 @@ class LinkHandlerImplTest {
       SlingHttpServletRequest.class, Resource.class
   })
   public static class TestLinkPostProcessor implements LinkProcessor {
+
     @Override
     public Link process(Link link) {
       String linkUrl = StringUtils.defaultString(link.getUrl()) + "/post1";

--- a/link/src/test/java/io/wcm/handler/link/type/ExternalLinkTypeTest.java
+++ b/link/src/test/java/io/wcm/handler/link/type/ExternalLinkTypeTest.java
@@ -59,10 +59,11 @@ class ExternalLinkTypeTest {
     LinkHandler linkHandler = AdaptTo.notNull(adaptable(), LinkHandler.class);
 
     SyntheticLinkResource linkResource = new SyntheticLinkResource(context.resourceResolver(),
+        "/content/dummy-path",
         ImmutableValueMap.builder()
-        .put(LinkNameConstants.PN_LINK_TYPE, ExternalLinkType.ID)
-        .put(LinkNameConstants.PN_LINK_EXTERNAL_REF, "")
-        .build());
+            .put(LinkNameConstants.PN_LINK_TYPE, ExternalLinkType.ID)
+            .put(LinkNameConstants.PN_LINK_EXTERNAL_REF, "")
+            .build());
 
     Link link = linkHandler.get(linkResource).build();
 
@@ -77,10 +78,11 @@ class ExternalLinkTypeTest {
     LinkHandler linkHandler = AdaptTo.notNull(adaptable(), LinkHandler.class);
 
     SyntheticLinkResource linkResource = new SyntheticLinkResource(context.resourceResolver(),
+        "/content/dummy-path",
         ImmutableValueMap.builder()
-        .put(LinkNameConstants.PN_LINK_TYPE, ExternalLinkType.ID)
-        .put(LinkNameConstants.PN_LINK_EXTERNAL_REF, "http://xyz/abc")
-        .build());
+            .put(LinkNameConstants.PN_LINK_TYPE, ExternalLinkType.ID)
+            .put(LinkNameConstants.PN_LINK_EXTERNAL_REF, "http://xyz/abc")
+            .build());
 
     Link link = linkHandler.get(linkResource).build();
 
@@ -92,7 +94,19 @@ class ExternalLinkTypeTest {
 
   @Test
   void testGetSyntheticLinkResource() {
-    Resource resource = ExternalLinkType.getSyntheticLinkResource(context.resourceResolver(), "http://dummy");
+    Resource resource = ExternalLinkType.getSyntheticLinkResource(context.resourceResolver(),
+        "/content/dummy-path",
+        "http://dummy");
+    ValueMap expected = ImmutableValueMap.of(LinkNameConstants.PN_LINK_TYPE, ExternalLinkType.ID,
+        LinkNameConstants.PN_LINK_EXTERNAL_REF, "http://dummy");
+    assertEquals(expected, ImmutableValueMap.copyOf(resource.getValueMap()));
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  void testGetSyntheticLinkResource_Deprecated() {
+    Resource resource = ExternalLinkType.getSyntheticLinkResource(context.resourceResolver(),
+        "http://dummy");
     ValueMap expected = ImmutableValueMap.of(LinkNameConstants.PN_LINK_TYPE, ExternalLinkType.ID,
         LinkNameConstants.PN_LINK_EXTERNAL_REF, "http://dummy");
     assertEquals(expected, ImmutableValueMap.copyOf(resource.getValueMap()));

--- a/link/src/test/java/io/wcm/handler/link/type/InternalCrossContextLinkTypeTest.java
+++ b/link/src/test/java/io/wcm/handler/link/type/InternalCrossContextLinkTypeTest.java
@@ -25,6 +25,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.sling.api.adapter.Adaptable;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ValueMap;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -111,22 +113,23 @@ class InternalCrossContextLinkTypeTest {
   }
 
   @Test
+  void testGetSyntheticLinkResource() {
+    Resource resource = InternalCrossContextLinkType.getSyntheticLinkResource(context.resourceResolver(),
+        "/content/dummy-path",
+        "/page/ref");
+    ValueMap expected = ImmutableValueMap.of(LinkNameConstants.PN_LINK_TYPE, InternalCrossContextLinkType.ID,
+        LinkNameConstants.PN_LINK_CROSSCONTEXT_CONTENT_REF, "/page/ref");
+    assertEquals(expected, ImmutableValueMap.copyOf(resource.getValueMap()));
+  }
+
+  @Test
   @SuppressWarnings("deprecation")
-  void testTargetPage_Deprecated() {
-    LinkHandler linkHandler = AdaptTo.notNull(adaptable(), LinkHandler.class);
-
-    SyntheticLinkResource linkResource = new SyntheticLinkResource(context.resourceResolver(),
-        ImmutableValueMap.builder()
-            .put(LinkNameConstants.PN_LINK_TYPE, InternalCrossContextLinkType.ID)
-            .put(LinkNameConstants.PN_LINK_CROSSCONTEXT_CONTENT_REF, targetPage.getPath())
-            .build());
-
-    Link link = linkHandler.get(linkResource).build();
-
-    assertTrue(link.isValid(), "link valid");
-    assertFalse(link.isLinkReferenceInvalid(), "link ref invalid");
-    assertEquals("http://www.dummysite.org/content/unittest/de_test/brand/de/section/content.html", link.getUrl(), "link url");
-    assertNotNull(link.getAnchor(), "anchor");
+  void testGetSyntheticLinkResource_Deprecated() {
+    Resource resource = InternalCrossContextLinkType.getSyntheticLinkResource(context.resourceResolver(),
+        "/page/ref");
+    ValueMap expected = ImmutableValueMap.of(LinkNameConstants.PN_LINK_TYPE, InternalCrossContextLinkType.ID,
+        LinkNameConstants.PN_LINK_CROSSCONTEXT_CONTENT_REF, "/page/ref");
+    assertEquals(expected, ImmutableValueMap.copyOf(resource.getValueMap()));
   }
 
 }

--- a/link/src/test/java/io/wcm/handler/link/type/InternalCrossContextLinkTypeTest.java
+++ b/link/src/test/java/io/wcm/handler/link/type/InternalCrossContextLinkTypeTest.java
@@ -77,10 +77,11 @@ class InternalCrossContextLinkTypeTest {
     LinkHandler linkHandler = AdaptTo.notNull(adaptable(), LinkHandler.class);
 
     SyntheticLinkResource linkResource = new SyntheticLinkResource(context.resourceResolver(),
+        "/content/dummy-path",
         ImmutableValueMap.builder()
             .put(LinkNameConstants.PN_LINK_TYPE, InternalCrossContextLinkType.ID)
             .put(LinkNameConstants.PN_LINK_CROSSCONTEXT_CONTENT_REF, targetPage.getPath())
-        .build());
+            .build());
 
     Link link = linkHandler.get(linkResource).build();
 
@@ -95,16 +96,36 @@ class InternalCrossContextLinkTypeTest {
     LinkHandler linkHandler = AdaptTo.notNull(adaptable(), LinkHandler.class);
 
     SyntheticLinkResource linkResource = new SyntheticLinkResource(context.resourceResolver(),
+        "/content/dummy-path",
         ImmutableValueMap.builder()
             .put(LinkNameConstants.PN_LINK_TYPE, InternalCrossContextLinkType.ID)
             .put(LinkNameConstants.PN_LINK_CROSSCONTEXT_CONTENT_REF, "/content/unittest/en_test/brand/en/section/content")
-        .build());
+            .build());
 
     Link link = linkHandler.get(linkResource).build();
 
     assertTrue(link.isValid(), "link valid");
     assertEquals("http://en.dummysite.org/content/unittest/en_test/brand/en/section/content.html",
         link.getUrl(), "link url");
+    assertNotNull(link.getAnchor(), "anchor");
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  void testTargetPage_Deprecated() {
+    LinkHandler linkHandler = AdaptTo.notNull(adaptable(), LinkHandler.class);
+
+    SyntheticLinkResource linkResource = new SyntheticLinkResource(context.resourceResolver(),
+        ImmutableValueMap.builder()
+            .put(LinkNameConstants.PN_LINK_TYPE, InternalCrossContextLinkType.ID)
+            .put(LinkNameConstants.PN_LINK_CROSSCONTEXT_CONTENT_REF, targetPage.getPath())
+            .build());
+
+    Link link = linkHandler.get(linkResource).build();
+
+    assertTrue(link.isValid(), "link valid");
+    assertFalse(link.isLinkReferenceInvalid(), "link ref invalid");
+    assertEquals("http://www.dummysite.org/content/unittest/de_test/brand/de/section/content.html", link.getUrl(), "link url");
     assertNotNull(link.getAnchor(), "anchor");
   }
 

--- a/link/src/test/java/io/wcm/handler/link/type/InternalCrossScopeLinkTypeTest.java
+++ b/link/src/test/java/io/wcm/handler/link/type/InternalCrossScopeLinkTypeTest.java
@@ -25,6 +25,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.sling.api.adapter.Adaptable;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ValueMap;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -112,21 +114,22 @@ class InternalCrossScopeLinkTypeTest {
   }
 
   @Test
-  void testTargetPage_Deprecated() {
-    LinkHandler linkHandler = AdaptTo.notNull(adaptable(), LinkHandler.class);
+  void testGetSyntheticLinkResource() {
+    Resource resource = InternalCrossScopeLinkType.getSyntheticLinkResource(context.resourceResolver(),
+        "/content/dummy-path",
+        "/page/ref");
+    ValueMap expected = ImmutableValueMap.of(LinkNameConstants.PN_LINK_TYPE, InternalCrossScopeLinkType.ID,
+        LinkNameConstants.PN_LINK_CONTENT_REF, "/page/ref");
+    assertEquals(expected, ImmutableValueMap.copyOf(resource.getValueMap()));
+  }
 
-    SyntheticLinkResource linkResource = new SyntheticLinkResource(context.resourceResolver(),
-        ImmutableValueMap.builder()
-            .put(LinkNameConstants.PN_LINK_TYPE, InternalCrossScopeLinkType.ID)
-            .put(LinkNameConstants.PN_LINK_CONTENT_REF, targetPage.getPath())
-            .build());
-
-    Link link = linkHandler.get(linkResource).build();
-
-    assertTrue(link.isValid(), "link valid");
-    assertFalse(link.isLinkReferenceInvalid(), "link ref invalid");
-    assertEquals("http://www.dummysite.org/content/unittest/de_test/brand/de/section/content.html", link.getUrl(), "link url");
-    assertNotNull(link.getAnchor(), "anchor");
+  @Test
+  void testGetSyntheticLinkResource_Deprecated() {
+    Resource resource = InternalCrossScopeLinkType.getSyntheticLinkResource(context.resourceResolver(),
+        "/page/ref");
+    ValueMap expected = ImmutableValueMap.of(LinkNameConstants.PN_LINK_TYPE, InternalCrossScopeLinkType.ID,
+        LinkNameConstants.PN_LINK_CONTENT_REF, "/page/ref");
+    assertEquals(expected, ImmutableValueMap.copyOf(resource.getValueMap()));
   }
 
 }

--- a/link/src/test/java/io/wcm/handler/link/type/InternalCrossScopeLinkTypeTest.java
+++ b/link/src/test/java/io/wcm/handler/link/type/InternalCrossScopeLinkTypeTest.java
@@ -78,10 +78,11 @@ class InternalCrossScopeLinkTypeTest {
     LinkHandler linkHandler = AdaptTo.notNull(adaptable(), LinkHandler.class);
 
     SyntheticLinkResource linkResource = new SyntheticLinkResource(context.resourceResolver(),
+        "/content/dummy-path",
         ImmutableValueMap.builder()
-        .put(LinkNameConstants.PN_LINK_TYPE, InternalCrossScopeLinkType.ID)
-        .put(LinkNameConstants.PN_LINK_CONTENT_REF, targetPage.getPath())
-        .build());
+            .put(LinkNameConstants.PN_LINK_TYPE, InternalCrossScopeLinkType.ID)
+            .put(LinkNameConstants.PN_LINK_CONTENT_REF, targetPage.getPath())
+            .build());
 
     Link link = linkHandler.get(linkResource).build();
 
@@ -96,16 +97,35 @@ class InternalCrossScopeLinkTypeTest {
     LinkHandler linkHandler = AdaptTo.notNull(adaptable(), LinkHandler.class);
 
     SyntheticLinkResource linkResource = new SyntheticLinkResource(context.resourceResolver(),
+        "/content/dummy-path",
         ImmutableValueMap.builder()
-        .put(LinkNameConstants.PN_LINK_TYPE, InternalCrossScopeLinkType.ID)
-        .put(LinkNameConstants.PN_LINK_CONTENT_REF, "/content/unittest/en_test/brand/en/section/content")
-        .build());
+            .put(LinkNameConstants.PN_LINK_TYPE, InternalCrossScopeLinkType.ID)
+            .put(LinkNameConstants.PN_LINK_CONTENT_REF, "/content/unittest/en_test/brand/en/section/content")
+            .build());
 
     Link link = linkHandler.get(linkResource).build();
 
     assertTrue(link.isValid(), "link valid");
     assertEquals("http://en.dummysite.org/content/unittest/en_test/brand/en/section/content.html",
         link.getUrl(), "link url");
+    assertNotNull(link.getAnchor(), "anchor");
+  }
+
+  @Test
+  void testTargetPage_Deprecated() {
+    LinkHandler linkHandler = AdaptTo.notNull(adaptable(), LinkHandler.class);
+
+    SyntheticLinkResource linkResource = new SyntheticLinkResource(context.resourceResolver(),
+        ImmutableValueMap.builder()
+            .put(LinkNameConstants.PN_LINK_TYPE, InternalCrossScopeLinkType.ID)
+            .put(LinkNameConstants.PN_LINK_CONTENT_REF, targetPage.getPath())
+            .build());
+
+    Link link = linkHandler.get(linkResource).build();
+
+    assertTrue(link.isValid(), "link valid");
+    assertFalse(link.isLinkReferenceInvalid(), "link ref invalid");
+    assertEquals("http://www.dummysite.org/content/unittest/de_test/brand/de/section/content.html", link.getUrl(), "link url");
     assertNotNull(link.getAnchor(), "anchor");
   }
 

--- a/link/src/test/java/io/wcm/handler/link/type/InternalLinkTypeTest.java
+++ b/link/src/test/java/io/wcm/handler/link/type/InternalLinkTypeTest.java
@@ -84,9 +84,10 @@ class InternalLinkTypeTest {
     LinkHandler linkHandler = AdaptTo.notNull(adaptable(), LinkHandler.class);
 
     SyntheticLinkResource linkResource = new SyntheticLinkResource(context.resourceResolver(),
+        "/content/dummy-path",
         ImmutableValueMap.builder()
-        .put(LinkNameConstants.PN_LINK_TYPE, InternalLinkType.ID)
-        .build());
+            .put(LinkNameConstants.PN_LINK_TYPE, InternalLinkType.ID)
+            .build());
 
     Link link = linkHandler.get(linkResource).build();
 
@@ -103,9 +104,10 @@ class InternalLinkTypeTest {
     LinkHandler linkHandler = AdaptTo.notNull(adaptable(), LinkHandler.class);
 
     SyntheticLinkResource linkResource = new SyntheticLinkResource(context.resourceResolver(),
+        "/content/dummy-path",
         ImmutableValueMap.builder()
             .put(LinkNameConstants.PN_LINK_TYPE, InternalLinkType.ID)
-        .build());
+            .build());
 
     Link link = linkHandler.get(linkResource).build();
 
@@ -120,10 +122,11 @@ class InternalLinkTypeTest {
     LinkHandler linkHandler = AdaptTo.notNull(adaptable(), LinkHandler.class);
 
     SyntheticLinkResource linkResource = new SyntheticLinkResource(context.resourceResolver(),
+        "/content/dummy-path",
         ImmutableValueMap.builder()
-        .put(LinkNameConstants.PN_LINK_TYPE, InternalLinkType.ID)
-        .put(LinkNameConstants.PN_LINK_CONTENT_REF, "/invalid/content/path")
-        .build());
+            .put(LinkNameConstants.PN_LINK_TYPE, InternalLinkType.ID)
+            .put(LinkNameConstants.PN_LINK_CONTENT_REF, "/invalid/content/path")
+            .build());
 
     Link link = linkHandler.get(linkResource).build();
 
@@ -144,10 +147,11 @@ class InternalLinkTypeTest {
     LinkHandler linkHandler = AdaptTo.notNull(adaptable(), LinkHandler.class);
 
     SyntheticLinkResource linkResource = new SyntheticLinkResource(context.resourceResolver(),
+        "/content/dummy-path",
         ImmutableValueMap.builder()
-        .put(LinkNameConstants.PN_LINK_TYPE, InternalLinkType.ID)
-        .put(LinkNameConstants.PN_LINK_CONTENT_REF, "/invalid/content/path")
-        .build());
+            .put(LinkNameConstants.PN_LINK_TYPE, InternalLinkType.ID)
+            .put(LinkNameConstants.PN_LINK_CONTENT_REF, "/invalid/content/path")
+            .build());
 
     Link link = linkHandler.get(linkResource).dummyLink(true).build();
 
@@ -163,10 +167,11 @@ class InternalLinkTypeTest {
     LinkHandler linkHandler = AdaptTo.notNull(adaptable(), LinkHandler.class);
 
     SyntheticLinkResource linkResource = new SyntheticLinkResource(context.resourceResolver(),
+        "/content/dummy-path",
         ImmutableValueMap.builder()
-        .put(LinkNameConstants.PN_LINK_TYPE, InternalLinkType.ID)
-        .put(LinkNameConstants.PN_LINK_CONTENT_REF, targetPage.getPath())
-        .build());
+            .put(LinkNameConstants.PN_LINK_TYPE, InternalLinkType.ID)
+            .put(LinkNameConstants.PN_LINK_CONTENT_REF, targetPage.getPath())
+            .build());
 
     Link link = linkHandler.get(linkResource).build();
 
@@ -210,9 +215,9 @@ class InternalLinkTypeTest {
 
     Page redirectInternalPage = context.create().page("/content/unittest/de_test/brand/de/section/redirectInternal",
         DummyAppTemplate.REDIRECT.getTemplatePath(), ImmutableValueMap.builder()
-        .put(LinkNameConstants.PN_LINK_TYPE, InternalLinkType.ID)
-        .put(LinkNameConstants.PN_LINK_CONTENT_REF, targetPage.getPath())
-        .build());
+            .put(LinkNameConstants.PN_LINK_TYPE, InternalLinkType.ID)
+            .put(LinkNameConstants.PN_LINK_CONTENT_REF, targetPage.getPath())
+            .build());
 
     Link link = linkHandler.get(redirectInternalPage).build();
 
@@ -232,9 +237,9 @@ class InternalLinkTypeTest {
 
     Page redirectInternalPage = context.create().page("/content/unittest/de_test/brand/de/section/redirectInternal",
         DummyAppTemplate.REDIRECT.getTemplatePath(), ImmutableValueMap.builder()
-        .put(LinkNameConstants.PN_LINK_TYPE, InternalLinkType.ID)
-        .put(LinkNameConstants.PN_LINK_CONTENT_REF, targetPage.getPath())
-        .build());
+            .put(LinkNameConstants.PN_LINK_TYPE, InternalLinkType.ID)
+            .put(LinkNameConstants.PN_LINK_CONTENT_REF, targetPage.getPath())
+            .build());
 
     Link link = linkHandler.get(redirectInternalPage).build();
 
@@ -249,15 +254,15 @@ class InternalLinkTypeTest {
 
     Page redirectInternalPage = context.create().page("/content/unittest/de_test/brand/de/section/redirectInternal",
         DummyAppTemplate.REDIRECT.getTemplatePath(), ImmutableValueMap.builder()
-        .put(LinkNameConstants.PN_LINK_TYPE, InternalLinkType.ID)
-        .put(LinkNameConstants.PN_LINK_CONTENT_REF, targetPage.getPath())
-        .build());
+            .put(LinkNameConstants.PN_LINK_TYPE, InternalLinkType.ID)
+            .put(LinkNameConstants.PN_LINK_CONTENT_REF, targetPage.getPath())
+            .build());
 
     Page redirectRedirectInternalPage = context.create().page("/content/unittest/de_test/brand/de/section/redirectRedirectInternal",
         DummyAppTemplate.REDIRECT.getTemplatePath(), ImmutableValueMap.builder()
-        .put(LinkNameConstants.PN_LINK_TYPE, InternalLinkType.ID)
-        .put(LinkNameConstants.PN_LINK_CONTENT_REF, redirectInternalPage.getPath())
-        .build());
+            .put(LinkNameConstants.PN_LINK_TYPE, InternalLinkType.ID)
+            .put(LinkNameConstants.PN_LINK_CONTENT_REF, redirectInternalPage.getPath())
+            .build());
 
     Link link = linkHandler.get(redirectRedirectInternalPage).build();
 
@@ -272,9 +277,9 @@ class InternalLinkTypeTest {
 
     Page redirectExternalPage = context.create().page("/content/unittest/de_test/brand/de/section/redirectExternal",
         DummyAppTemplate.REDIRECT.getTemplatePath(), ImmutableValueMap.builder()
-        .put(LinkNameConstants.PN_LINK_TYPE, ExternalLinkType.ID)
-        .put(LinkNameConstants.PN_LINK_EXTERNAL_REF, "http://xyz/abc")
-        .build());
+            .put(LinkNameConstants.PN_LINK_TYPE, ExternalLinkType.ID)
+            .put(LinkNameConstants.PN_LINK_EXTERNAL_REF, "http://xyz/abc")
+            .build());
 
     Link link = linkHandler.get(redirectExternalPage).build();
 
@@ -292,14 +297,14 @@ class InternalLinkTypeTest {
 
     Page redirectInternalCyclic1Page = context.create().page(redirectInternalCyclic1Path,
         DummyAppTemplate.REDIRECT.getTemplatePath(), ImmutableValueMap.builder()
-        .put(LinkNameConstants.PN_LINK_TYPE, InternalLinkType.ID)
-        .put(LinkNameConstants.PN_LINK_CONTENT_REF, redirectInternalCyclic2Path)
-        .build());
+            .put(LinkNameConstants.PN_LINK_TYPE, InternalLinkType.ID)
+            .put(LinkNameConstants.PN_LINK_CONTENT_REF, redirectInternalCyclic2Path)
+            .build());
     Page redirectInternalCyclic2Page = context.create().page(redirectInternalCyclic2Path,
         DummyAppTemplate.REDIRECT.getTemplatePath(), ImmutableValueMap.builder()
-        .put(LinkNameConstants.PN_LINK_TYPE, InternalLinkType.ID)
-        .put(LinkNameConstants.PN_LINK_CONTENT_REF, redirectInternalCyclic1Path)
-        .build());
+            .put(LinkNameConstants.PN_LINK_TYPE, InternalLinkType.ID)
+            .put(LinkNameConstants.PN_LINK_CONTENT_REF, redirectInternalCyclic1Path)
+            .build());
 
     Link link = linkHandler.get(redirectInternalCyclic1Page).build();
 
@@ -320,11 +325,11 @@ class InternalLinkTypeTest {
 
     Page integratorPage = context.create().page("/content/unittest/de_test/brand/de/section/integrator",
         DummyAppTemplate.INTEGRATOR.getTemplatePath(), ImmutableValueMap.builder()
-        .put(IntegratorNameConstants.PN_INTEGRATOR_MODE, IntegratorModes.SIMPLE.getId())
-        .put(IntegratorNameConstants.PN_INTEGRATOR_PROTOCOL, IntegratorProtocol.HTTP.name())
-        .put(LinkNameConstants.PN_LINK_TYPE, ExternalLinkType.ID)
-        .put(LinkNameConstants.PN_LINK_EXTERNAL_REF, "http://xyz/app")
-        .build());
+            .put(IntegratorNameConstants.PN_INTEGRATOR_MODE, IntegratorModes.SIMPLE.getId())
+            .put(IntegratorNameConstants.PN_INTEGRATOR_PROTOCOL, IntegratorProtocol.HTTP.name())
+            .put(LinkNameConstants.PN_LINK_TYPE, ExternalLinkType.ID)
+            .put(LinkNameConstants.PN_LINK_EXTERNAL_REF, "http://xyz/app")
+            .build());
 
     Link link = linkHandler.get(integratorPage).build();
 
@@ -344,11 +349,11 @@ class InternalLinkTypeTest {
 
     Page integratorPage = context.create().page("/content/unittest/de_test/brand/de/section/integrator",
         DummyAppTemplate.INTEGRATOR.getTemplatePath(), ImmutableValueMap.builder()
-        .put(IntegratorNameConstants.PN_INTEGRATOR_MODE, IntegratorModes.SIMPLE.getId())
-        .put(IntegratorNameConstants.PN_INTEGRATOR_PROTOCOL, IntegratorProtocol.HTTP.name())
-        .put(LinkNameConstants.PN_LINK_TYPE, ExternalLinkType.ID)
-        .put(LinkNameConstants.PN_LINK_EXTERNAL_REF, "http://xyz/app")
-        .build());
+            .put(IntegratorNameConstants.PN_INTEGRATOR_MODE, IntegratorModes.SIMPLE.getId())
+            .put(IntegratorNameConstants.PN_INTEGRATOR_PROTOCOL, IntegratorProtocol.HTTP.name())
+            .put(LinkNameConstants.PN_LINK_TYPE, ExternalLinkType.ID)
+            .put(LinkNameConstants.PN_LINK_EXTERNAL_REF, "http://xyz/app")
+            .build());
 
     Link link = linkHandler.get(integratorPage).build();
 
@@ -362,10 +367,11 @@ class InternalLinkTypeTest {
     LinkHandler linkHandler = AdaptTo.notNull(adaptable(), LinkHandler.class);
 
     SyntheticLinkResource linkResource = new SyntheticLinkResource(context.resourceResolver(),
+        "/content/dummy-path",
         ImmutableValueMap.builder()
-        .put(LinkNameConstants.PN_LINK_TYPE, InternalLinkType.ID)
-        .put(LinkNameConstants.PN_LINK_CONTENT_REF, "/content/unittest/en_test/brand/en/section/content")
-        .build());
+            .put(LinkNameConstants.PN_LINK_TYPE, InternalLinkType.ID)
+            .put(LinkNameConstants.PN_LINK_CONTENT_REF, "/content/unittest/en_test/brand/en/section/content")
+            .build());
 
     Link link = linkHandler.get(linkResource).build();
 
@@ -403,11 +409,12 @@ class InternalLinkTypeTest {
     LinkHandler linkHandler = AdaptTo.notNull(adaptable(), LinkHandler.class);
 
     SyntheticLinkResource linkResource = new SyntheticLinkResource(context.resourceResolver(),
+        "/content/dummy-path",
         ImmutableValueMap.builder()
-        .put(LinkNameConstants.PN_LINK_TYPE, InternalLinkType.ID)
-        .put(LinkNameConstants.PN_LINK_CONTENT_REF, targetPage.getPath())
-        .put(LinkNameConstants.PN_LINK_QUERY_PARAM, "p1=abc&p2=def")
-        .build());
+            .put(LinkNameConstants.PN_LINK_TYPE, InternalLinkType.ID)
+            .put(LinkNameConstants.PN_LINK_CONTENT_REF, targetPage.getPath())
+            .put(LinkNameConstants.PN_LINK_QUERY_PARAM, "p1=abc&p2=def")
+            .build());
 
     Link link = linkHandler.get(linkResource).build();
 
@@ -422,11 +429,12 @@ class InternalLinkTypeTest {
     LinkHandler linkHandler = AdaptTo.notNull(adaptable(), LinkHandler.class);
 
     SyntheticLinkResource linkResource = new SyntheticLinkResource(context.resourceResolver(),
+        "/content/dummy-path",
         ImmutableValueMap.builder()
-        .put(LinkNameConstants.PN_LINK_TYPE, InternalLinkType.ID)
-        .put(LinkNameConstants.PN_LINK_CONTENT_REF, targetPage.getPath())
-        .put(LinkNameConstants.PN_LINK_FRAGMENT, "anchor1")
-        .build());
+            .put(LinkNameConstants.PN_LINK_TYPE, InternalLinkType.ID)
+            .put(LinkNameConstants.PN_LINK_CONTENT_REF, targetPage.getPath())
+            .put(LinkNameConstants.PN_LINK_FRAGMENT, "anchor1")
+            .build());
 
     Link link = linkHandler.get(linkResource).build();
 
@@ -441,12 +449,13 @@ class InternalLinkTypeTest {
     LinkHandler linkHandler = AdaptTo.notNull(adaptable(), LinkHandler.class);
 
     SyntheticLinkResource linkResource = new SyntheticLinkResource(context.resourceResolver(),
+        "/content/dummy-path",
         ImmutableValueMap.builder()
-        .put(LinkNameConstants.PN_LINK_TYPE, InternalLinkType.ID)
-        .put(LinkNameConstants.PN_LINK_CONTENT_REF, targetPage.getPath())
-        .put(LinkNameConstants.PN_LINK_QUERY_PARAM, "p1=abc&p2=def")
-        .put(LinkNameConstants.PN_LINK_FRAGMENT, "anchor1")
-        .build());
+            .put(LinkNameConstants.PN_LINK_TYPE, InternalLinkType.ID)
+            .put(LinkNameConstants.PN_LINK_CONTENT_REF, targetPage.getPath())
+            .put(LinkNameConstants.PN_LINK_QUERY_PARAM, "p1=abc&p2=def")
+            .put(LinkNameConstants.PN_LINK_FRAGMENT, "anchor1")
+            .build());
 
     Link link = linkHandler.get(linkResource).build();
 
@@ -461,10 +470,11 @@ class InternalLinkTypeTest {
     LinkHandler linkHandler = AdaptTo.notNull(adaptable(), LinkHandler.class);
 
     SyntheticLinkResource linkResource = new SyntheticLinkResource(context.resourceResolver(),
+        "/content/dummy-path",
         ImmutableValueMap.builder()
-        .put(LinkNameConstants.PN_LINK_TYPE, InternalLinkType.ID)
-        .put(LinkNameConstants.PN_LINK_CONTENT_REF, targetPage.getPath())
-        .build());
+            .put(LinkNameConstants.PN_LINK_TYPE, InternalLinkType.ID)
+            .put(LinkNameConstants.PN_LINK_CONTENT_REF, targetPage.getPath())
+            .build());
 
     Link link = linkHandler.get(linkResource).queryString("p5=abc&p6=xyz").fragment("anchor2").build();
 
@@ -479,12 +489,13 @@ class InternalLinkTypeTest {
     LinkHandler linkHandler = AdaptTo.notNull(adaptable(), LinkHandler.class);
 
     SyntheticLinkResource linkResource = new SyntheticLinkResource(context.resourceResolver(),
+        "/content/dummy-path",
         ImmutableValueMap.builder()
-        .put(LinkNameConstants.PN_LINK_TYPE, InternalLinkType.ID)
-        .put(LinkNameConstants.PN_LINK_CONTENT_REF, targetPage.getPath())
-        .put(LinkNameConstants.PN_LINK_QUERY_PARAM, "p1=abc&p2=def")
-        .put(LinkNameConstants.PN_LINK_FRAGMENT, "anchor1")
-        .build());
+            .put(LinkNameConstants.PN_LINK_TYPE, InternalLinkType.ID)
+            .put(LinkNameConstants.PN_LINK_CONTENT_REF, targetPage.getPath())
+            .put(LinkNameConstants.PN_LINK_QUERY_PARAM, "p1=abc&p2=def")
+            .put(LinkNameConstants.PN_LINK_FRAGMENT, "anchor1")
+            .build());
 
     Link link = linkHandler.get(linkResource).queryString("p5=abc&p6=xyz").fragment("anchor2").build();
 
@@ -496,7 +507,19 @@ class InternalLinkTypeTest {
 
   @Test
   void testGetSyntheticLinkResource() {
-    Resource resource = InternalLinkType.getSyntheticLinkResource(context.resourceResolver(), "/page/ref");
+    Resource resource = InternalLinkType.getSyntheticLinkResource(context.resourceResolver(),
+        "/content/dummy-path",
+        "/page/ref");
+    ValueMap expected = ImmutableValueMap.of(LinkNameConstants.PN_LINK_TYPE, InternalLinkType.ID,
+        LinkNameConstants.PN_LINK_CONTENT_REF, "/page/ref");
+    assertEquals(expected, ImmutableValueMap.copyOf(resource.getValueMap()));
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  void testGetSyntheticLinkResource_Deprecated() {
+    Resource resource = InternalLinkType.getSyntheticLinkResource(context.resourceResolver(),
+        "/page/ref");
     ValueMap expected = ImmutableValueMap.of(LinkNameConstants.PN_LINK_TYPE, InternalLinkType.ID,
         LinkNameConstants.PN_LINK_CONTENT_REF, "/page/ref");
     assertEquals(expected, ImmutableValueMap.copyOf(resource.getValueMap()));

--- a/link/src/test/java/io/wcm/handler/link/type/MediaLinkTypeTest.java
+++ b/link/src/test/java/io/wcm/handler/link/type/MediaLinkTypeTest.java
@@ -61,9 +61,10 @@ class MediaLinkTypeTest {
     LinkHandler linkHandler = AdaptTo.notNull(adaptable(), LinkHandler.class);
 
     SyntheticLinkResource linkResource = new SyntheticLinkResource(context.resourceResolver(),
+        "/content/dummy-path",
         ImmutableValueMap.builder()
-        .put(LinkNameConstants.PN_LINK_TYPE, MediaLinkType.ID)
-        .build());
+            .put(LinkNameConstants.PN_LINK_TYPE, MediaLinkType.ID)
+            .build());
 
     Link link = linkHandler.get(linkResource).build();
 
@@ -78,10 +79,11 @@ class MediaLinkTypeTest {
     LinkHandler linkHandler = AdaptTo.notNull(adaptable(), LinkHandler.class);
 
     SyntheticLinkResource linkResource = new SyntheticLinkResource(context.resourceResolver(),
+        "/content/dummy-path",
         ImmutableValueMap.builder()
-        .put(LinkNameConstants.PN_LINK_TYPE, MediaLinkType.ID)
-        .put(LinkNameConstants.PN_LINK_MEDIA_REF, "/invalid/media/link")
-        .build());
+            .put(LinkNameConstants.PN_LINK_TYPE, MediaLinkType.ID)
+            .put(LinkNameConstants.PN_LINK_MEDIA_REF, "/invalid/media/link")
+            .build());
 
     Link link = linkHandler.get(linkResource).build();
 
@@ -102,10 +104,11 @@ class MediaLinkTypeTest {
     LinkHandler linkHandler = AdaptTo.notNull(adaptable(), LinkHandler.class);
 
     SyntheticLinkResource linkResource = new SyntheticLinkResource(context.resourceResolver(),
+        "/content/dummy-path",
         ImmutableValueMap.builder()
-        .put(LinkNameConstants.PN_LINK_TYPE, MediaLinkType.ID)
-        .put(LinkNameConstants.PN_LINK_MEDIA_REF, "/invalid/media/link")
-        .build());
+            .put(LinkNameConstants.PN_LINK_TYPE, MediaLinkType.ID)
+            .put(LinkNameConstants.PN_LINK_MEDIA_REF, "/invalid/media/link")
+            .build());
 
     Link link = linkHandler.get(linkResource).dummyLink(true).dummyLinkUrl("/my/dummy/url").build();
 
@@ -122,6 +125,7 @@ class MediaLinkTypeTest {
   //  LinkHandler linkHandler = AdaptTo.notNull(adaptable(), LinkHandler.class);
   //
   //  SyntheticLinkResource linkResource = new SyntheticLinkResource(context.resourceResolver(),
+  //      "/content/dummy-path",
   //      ImmutableValueMap.builder()
   //          .put(LinkNameConstants.PN_LINK_TYPE, MediaLinkType.ID)
   //          .put(LinkNameConstants.PN_LINK_MEDIA_REF, "/content/dummymedia/image1")
@@ -139,10 +143,11 @@ class MediaLinkTypeTest {
     LinkHandler linkHandler = AdaptTo.notNull(adaptable(), LinkHandler.class);
 
     SyntheticLinkResource linkResource = new SyntheticLinkResource(context.resourceResolver(),
+        "/content/dummy-path",
         ImmutableValueMap.builder()
-        .put(LinkNameConstants.PN_LINK_TYPE, MediaLinkType.ID)
-        .put(LinkNameConstants.PN_LINK_MEDIA_REF, "/content/dummymedia/pdf1")
-        .build());
+            .put(LinkNameConstants.PN_LINK_TYPE, MediaLinkType.ID)
+            .put(LinkNameConstants.PN_LINK_MEDIA_REF, "/content/dummymedia/pdf1")
+            .build());
 
     Link link = linkHandler.get(linkResource).build();
 
@@ -153,7 +158,19 @@ class MediaLinkTypeTest {
 
   @Test
   void testGetSyntheticLinkResource() {
-    Resource resource = MediaLinkType.getSyntheticLinkResource(context.resourceResolver(), "/media/ref");
+    Resource resource = MediaLinkType.getSyntheticLinkResource(context.resourceResolver(),
+        "/content/dummy-path",
+        "/media/ref");
+    ValueMap expected = ImmutableValueMap.of(LinkNameConstants.PN_LINK_TYPE, MediaLinkType.ID,
+        LinkNameConstants.PN_LINK_MEDIA_REF, "/media/ref");
+    assertEquals(expected, ImmutableValueMap.copyOf(resource.getValueMap()));
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  void testGetSyntheticLinkResource_Deprecated() {
+    Resource resource = MediaLinkType.getSyntheticLinkResource(context.resourceResolver(),
+        "/media/ref");
     ValueMap expected = ImmutableValueMap.of(LinkNameConstants.PN_LINK_TYPE, MediaLinkType.ID,
         LinkNameConstants.PN_LINK_MEDIA_REF, "/media/ref");
     assertEquals(expected, ImmutableValueMap.copyOf(resource.getValueMap()));

--- a/link/src/test/java/io/wcm/handler/link/type/helpers/InternalLinkResolverTest.java
+++ b/link/src/test/java/io/wcm/handler/link/type/helpers/InternalLinkResolverTest.java
@@ -71,10 +71,12 @@ class InternalLinkResolverTest {
   void testTargetPage_RewritePathToContext() {
     InternalLinkResolver resolver = AdaptTo.notNull(context.request(), InternalLinkResolver.class);
 
-    SyntheticLinkResource linkResource = new SyntheticLinkResource(context.resourceResolver(), ImmutableValueMap.builder()
-        .put(LinkNameConstants.PN_LINK_TYPE, InternalLinkType.ID)
-        .put(LinkNameConstants.PN_LINK_CONTENT_REF, "/content/unittest/en_test/brand/en/section/content")
-        .build());
+    SyntheticLinkResource linkResource = new SyntheticLinkResource(context.resourceResolver(),
+        "/content/dummy-path",
+        ImmutableValueMap.builder()
+            .put(LinkNameConstants.PN_LINK_TYPE, InternalLinkType.ID)
+            .put(LinkNameConstants.PN_LINK_CONTENT_REF, "/content/unittest/en_test/brand/en/section/content")
+            .build());
 
     LinkRequest linkRequest = new LinkRequest(linkResource, null, null);
     Link link = new Link(new InternalLinkType(), linkRequest);
@@ -91,10 +93,12 @@ class InternalLinkResolverTest {
   void testTargetPageOtherSite_NoRewritePathToContext() {
     InternalLinkResolver resolver = AdaptTo.notNull(context.request(), InternalLinkResolver.class);
 
-    SyntheticLinkResource linkResource = new SyntheticLinkResource(context.resourceResolver(), ImmutableValueMap.builder()
-        .put(LinkNameConstants.PN_LINK_TYPE, InternalLinkType.ID)
-        .put(LinkNameConstants.PN_LINK_CONTENT_REF, "/content/unittest/en_test/brand/en/section/content")
-        .build());
+    SyntheticLinkResource linkResource = new SyntheticLinkResource(context.resourceResolver(),
+        "/content/dummy-path",
+        ImmutableValueMap.builder()
+            .put(LinkNameConstants.PN_LINK_TYPE, InternalLinkType.ID)
+            .put(LinkNameConstants.PN_LINK_CONTENT_REF, "/content/unittest/en_test/brand/en/section/content")
+            .build());
 
     LinkRequest linkRequest = new LinkRequest(linkResource, null, null);
     Link link = new Link(new InternalLinkType(), linkRequest);


### PR DESCRIPTION
Allow to specify a path for the synthetic resource, and deprecate the signatures without path.

Without a valid application-specific path the wrong handler configuration may be looked up via context-aware services.