### PR TITLE
Fall back to getting the current page path from the item URL parameter

### DIFF
--- a/richtext/changes.xml
+++ b/richtext/changes.xml
@@ -23,6 +23,12 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
+    <release version="1.3.4" date="not released">
+      <action type="fix" dev="mwehner">
+        RTE link plugin: Get the current page path from the item URL parameter if the RTE is used in page properties.
+      </action>
+    </release>
+
     <release version="1.3.2" date="2019-08-23">
       <action type="update" dev="sseifert">
         Always specify a path for link resources.

--- a/richtext/src/main/webapp/app-root/clientlibs/rte.plugins/js/linkPlugin.js
+++ b/richtext/src/main/webapp/app-root/clientlibs/rte.plugins/js/linkPlugin.js
@@ -14,19 +14,18 @@
       config.linkDialogConfig.dialogProperties = config.linkDialogConfig.dialogProperties || {};
       var dialogProperties = config.linkDialogConfig.dialogProperties;
 
-      // get link plugin configuration for current content page
-      // (either from Granite author context or the item URL parameter when used in the page properties)
-      var currentPagePath = Granite && Granite.author && Granite.author.ContentFrame ?
-          Granite.author.ContentFrame.getContentPath() : this.getParameterByName("item");
-      var pluginConfigUrl = currentPagePath + ".wcmio-handler-richtext-rte-plugins-links-config.json";
-      $.get({
-        url: pluginConfigUrl,
-        success: function(result) {
-          dialogProperties.linkTypes = dialogProperties.linkTypes || result.linkTypes;
-          dialogProperties.rootPaths = dialogProperties.rootPaths || result.rootPaths;
-        },
-        async: false
-      });
+      var currentPagePath = this.detectCurrentPagePath();
+      if (currentPagePath) {
+        var pluginConfigUrl = currentPagePath + ".wcmio-handler-richtext-rte-plugins-links-config.json";
+        $.get({
+          url: pluginConfigUrl,
+          success: function(result) {
+            dialogProperties.linkTypes = dialogProperties.linkTypes || result.linkTypes;
+            dialogProperties.rootPaths = dialogProperties.rootPaths || result.rootPaths;
+          },
+          async: false
+        });
+      }
 
       // fallback if JSON call was not successful or did not return link types
       dialogProperties.linkTypes = dialogProperties.linkTypes || {
@@ -68,6 +67,23 @@
       this.inherited(arguments);
     },
 
+    /**
+     * Detects the current page path. May return null.
+     */ 
+    detectCurrentPagePath: function() {
+      
+      // try get get current page path from ContentFrame (works for IPE and in component edit dialogs)
+      if (Granite && Granite.author && Granite.author.ContentFrame) {
+        return Granite.author.ContentFrame.getContentPath();
+      }
+      
+      // if we are in page properties dialog - try to get the item URL parameter
+      return this.getParameterByName("item");
+    },
+
+    /**
+     * Gets named request parameter from current URL.
+     */
     getParameterByName: function(name) {
       name = name.replace(/[\[]/, "\\\[").replace(/[\]]/, "\\\]");
       var regexS = "[?&]" + name + "=([^&#]*)";

--- a/richtext/src/main/webapp/app-root/clientlibs/rte.plugins/js/linkPlugin.js
+++ b/richtext/src/main/webapp/app-root/clientlibs/rte.plugins/js/linkPlugin.js
@@ -15,7 +15,9 @@
       var dialogProperties = config.linkDialogConfig.dialogProperties;
 
       // get link plugin configuration for current content page
-      var currentPagePath = Granite.author.ContentFrame.getContentPath();
+      // (either from Granite author context or the item URL parameter when used in the page properties)
+      var currentPagePath = Granite && Granite.author && Granite.author.ContentFrame ?
+          Granite.author.ContentFrame.getContentPath() : this.getParameterByName("item");
       var pluginConfigUrl = currentPagePath + ".wcmio-handler-richtext-rte-plugins-links-config.json";
       $.get({
         url: pluginConfigUrl,
@@ -64,6 +66,18 @@
       tbGenerator.registerIcon("wcmio.handler.richtext.links#unlink", "linkOff");
       // call the "super" method
       this.inherited(arguments);
+    },
+
+    getParameterByName: function(name) {
+      name = name.replace(/[\[]/, "\\\[").replace(/[\]]/, "\\\]");
+      var regexS = "[?&]" + name + "=([^&#]*)";
+      var regex = new RegExp(regexS, "g");
+      var match = regex.exec(window.location.search);
+      var result = null;
+      if (match) {
+        result = decodeURIComponent(match[1].replace(/\+/g, " "));
+      }
+      return result;
     }
 
   });


### PR DESCRIPTION
When the link plugin is used in the page properties `Granite.author` will not be available and the plugin will throw an error which prevents initialization of the whole RTE. You don't even need to use any features from the plugin for the error to occur.
This adds a fallback using the `item` URL parameter which contains the URL of the current page for the page properties editor. 