### PR TITLE
MediaNameConstants: fix typo in responsiveImageSettings for child resources

### DIFF
--- a/media/changes.xml
+++ b/media/changes.xml
@@ -23,6 +23,12 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
+    <release version="1.7.4" date="not released">
+      <action type="fix" dev="mrozati">
+        MediaNameConstants: fix typo in responsiveImageSettings for child resources
+      </action>
+    </release>
+
     <release version="1.7.2" date="2019-09-10">
       <action type="update" dev="sseifert" issue="WHAN-25">
         Granite UI components for file upload and path field: Support "appendPath" parameter.

--- a/media/src/main/java/io/wcm/handler/media/MediaNameConstants.java
+++ b/media/src/main/java/io/wcm/handler/media/MediaNameConstants.java
@@ -203,7 +203,7 @@ public final class MediaNameConstants {
    * Child node is to be defined on component or in policy.
    * </p>
    */
-  public static final @NotNull String NN_COMPONENT_MEDIA_RESPONSIVE_IMAGE_SIZES = "wcmio:mediaRepsonsiveImageSizes";
+  public static final @NotNull String NN_COMPONENT_MEDIA_RESPONSIVE_IMAGE_SIZES = "wcmio:mediaResponsiveImageSizes";
 
   /**
    * Defines "picture sources" responsive image setting.
@@ -213,6 +213,6 @@ public final class MediaNameConstants {
    * Child node is to be defined on component or in policy.
    * </p>
    */
-  public static final @NotNull String NN_COMPONENT_MEDIA_RESPONSIVE_PICTURE_SOURCES = "wcmio:mediaRepsonsivePictureSources";
+  public static final @NotNull String NN_COMPONENT_MEDIA_RESPONSIVE_PICTURE_SOURCES = "wcmio:mediaResponsivePictureSources";
 
 }

--- a/media/src/main/webapp/app-root/components/global/include/responsiveImageSettings.json
+++ b/media/src/main/webapp/app-root/components/global/include/responsiveImageSettings.json
@@ -76,13 +76,13 @@
             },
             "sizes": {
               "sling:resourceType": "granite/ui/components/coral/foundation/form/textfield",
-              "name": "./wcmio:mediaRepsonsiveImageSizes/sizes",
+              "name": "./wcmio:mediaResponsiveImageSizes/sizes",
               "fieldLabel": "io.wcm.handler.media.components.global.include.responsiveImageSettings.imageSizes.sizes.fieldLabel",
               "fieldDescription": "io.wcm.handler.media.components.global.include.responsiveImageSettings.imageSizes.sizes.fieldDescription"
             },
             "widths": {
               "sling:resourceType": "granite/ui/components/coral/foundation/form/textfield",
-              "name": "./wcmio:mediaRepsonsiveImageSizes/widths",
+              "name": "./wcmio:mediaResponsiveImageSizes/widths",
               "fieldLabel": "io.wcm.handler.media.components.global.include.responsiveImageSettings.imageSizes.widths.fieldLabel",
               "fieldDescription": "io.wcm.handler.media.components.global.include.responsiveImageSettings.imageSizes.widths.fieldDescription",
               "validation": ["wcmio.handler.media.responsiveWidths"]
@@ -97,12 +97,12 @@
             "showhidetargetvalue": "pictureSources"
           },
           "items": {
-            "mediaRepsonsivePictureSources": {
+            "mediaResponsivePictureSources": {
               "sling:resourceType": "granite/ui/components/coral/foundation/form/multifield",
               "composite": true,
               "field": {
                 "sling:resourceType": "granite/ui/components/coral/foundation/container",
-                "name": "./wcmio:mediaRepsonsivePictureSources",
+                "name": "./wcmio:mediaResponsivePictureSources",
                 "items": {
                   "mediaFormat": {
                     "sling:resourceType": "wcm-io/handler/media/components/granite/form/mediaformatselect",

--- a/media/src/site/markdown/component-properties.md
+++ b/media/src/site/markdown/component-properties.md
@@ -26,9 +26,9 @@ The following component properties are supported:
 | `wcmio:mediaResponsiveType`           | Set responsive image handling type explicitly by setting to `imageSizes` or `pictureSources`.
 
 
-#### Child resource `wcmio:mediaRepsonsiveImageSizes`
+#### Child resource `wcmio:mediaResponsiveImageSizes`
 
-By defining a child resource named `wcmio:mediaRepsonsiveImageSizes` the responsive image mode with setting `sizes` and `srcset` attributes on the `img` element is enabled. The child resource has these properties:
+By defining a child resource named `wcmio:mediaResponsiveImageSizes` the responsive image mode with setting `sizes` and `srcset` attributes on the `img` element is enabled. The child resource has these properties:
 
 | Property name | Description
 |---------------|---------------------------------------------------------------------
@@ -36,9 +36,9 @@ By defining a child resource named `wcmio:mediaRepsonsiveImageSizes` the respons
 | `widths`      | Widths for the renditions in the `srcset` attribute, based on the primary media format. Separate widths by ','. Suffix optional widths with '?'.",
 
 
-#### Child resource `wcmio:mediaRepsonsivePictureSources`
+#### Child resource `wcmio:mediaResponsivePictureSources`
 
-By defining a child resource named `wcmio:mediaRepsonsivePictureSources` the responsive image mode with setting `picture` and `source` elements enabled. The child resource has a list of additional child resources, with the following properties for each of them:
+By defining a child resource named `wcmio:mediaResponsivePictureSources` the responsive image mode with setting `picture` and `source` elements enabled. The child resource has a list of additional child resources, with the following properties for each of them:
 
 | Property name | Description
 |---------------|---------------------------------------------------------------------


### PR DESCRIPTION
renamed `repsonsiveImage` to `responsiveImage`