### PR TITLE
Adding MediaHandler.get(String mediaRef, Resource resource)

### DIFF
--- a/media/changes.xml
+++ b/media/changes.xml
@@ -23,6 +23,12 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
+    <release version="1.9.0" date="not released">
+      <action type="add" dev="mceruti">
+        MediaHandler: Adds MediaHandler.get(String, Resource) that allows building a media from it's path while still looking up policy/component level settings from the given context resource, like it is done when building a media using MediaHandler.get(Resource). Requires the ComponentPropertyResolverFactory to work and be <![CDATA[<a href="https://wcm.io/wcm/commons/configuration.html">configured</a>]]> properly.
+      </action>
+    </release>
+
     <release version="1.8.2" date="2020-01-30">
       <action type="update" dev="sseifert">
         Detect media dimensions for original renditions for non-image binaries (from asset metadata).

--- a/media/src/main/java/io/wcm/handler/media/MediaHandler.java
+++ b/media/src/main/java/io/wcm/handler/media/MediaHandler.java
@@ -21,6 +21,7 @@ package io.wcm.handler.media;
 
 import org.apache.sling.api.resource.Resource;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.osgi.annotation.versioning.ProviderType;
 
 import io.wcm.handler.commons.dom.HtmlElement;
@@ -71,11 +72,23 @@ public interface MediaHandler {
 
   /**
    * Build media which is referenced via its string address.
+   * Same as <code>get(mediaRef,null)</code>
    * @param mediaRef Reference to media item (in most cases a repository path to the DAM asset).
    * @return Media builder
+   * @see #get(String, Resource)
    */
   @NotNull
   MediaBuilder get(String mediaRef);
+
+  /**
+   * Build media which is referenced via its string address.
+   * @param mediaRef Reference to media item (in most cases a repository path to the DAM asset).
+   * @param contextResource optionally used to resolve component/policy level properties affecting media resolving from
+   *          the component associated with the given resource
+   * @return Media builder
+   */
+  @NotNull
+  MediaBuilder get(String mediaRef, @Nullable Resource contextResource);
 
   /**
    * Build media which is referenced via its string address.

--- a/media/src/main/java/io/wcm/handler/media/MediaRequest.java
+++ b/media/src/main/java/io/wcm/handler/media/MediaRequest.java
@@ -106,11 +106,6 @@ public final class MediaRequest {
     this.mediaRef = mediaRef;
     this.mediaArgs = mediaArgs != null ? mediaArgs : new MediaArgs();
     this.mediaPropertyNames = mediaPropertyNames != null ? mediaPropertyNames : new MediaPropertyNames();
-
-    // validate parameters
-    if (this.resource != null && this.mediaRef != null) {
-      throw new IllegalArgumentException("Set resource or media ref, not both.");
-    }
   }
 
   /**

--- a/media/src/main/java/io/wcm/handler/media/impl/MediaBuilderImpl.java
+++ b/media/src/main/java/io/wcm/handler/media/impl/MediaBuilderImpl.java
@@ -66,17 +66,25 @@ final class MediaBuilderImpl implements MediaBuilder {
     this.mediaRef = null;
     this.mediaHandler = mediaHandler;
 
-    // resolve default settings from content policies and component properties
     if (resource != null) {
-      try (MediaComponentPropertyResolver resolver = getMediaComponentPropertyResolver(resource, componentPropertyResolverFactory)) {
-        mediaArgs.mediaFormatOptions(resolver.getMediaFormatOptions());
-        mediaArgs.autoCrop(resolver.isAutoCrop());
-        mediaArgs.imageSizes(resolver.getImageSizes());
-        mediaArgs.pictureSources(resolver.getPictureSources());
-      }
-      catch (Exception ex) {
-        log.warn("Error closing component property resolver.", ex);
-      }
+      resolveDefaultSettingsFromPolicyAndComponent(resource, componentPropertyResolverFactory);
+    }
+  }
+
+  /**
+   * Resolve default settings from content policies and component properties
+   * @param contextResource context resource
+   * @param componentPropertyResolverFactory factory to create a component property resolver
+   */
+  private void resolveDefaultSettingsFromPolicyAndComponent(Resource contextResource, ComponentPropertyResolverFactory componentPropertyResolverFactory) {
+    try (MediaComponentPropertyResolver resolver = getMediaComponentPropertyResolver(contextResource, componentPropertyResolverFactory)) {
+      mediaArgs.mediaFormatOptions(resolver.getMediaFormatOptions());
+      mediaArgs.autoCrop(resolver.isAutoCrop());
+      mediaArgs.imageSizes(resolver.getImageSizes());
+      mediaArgs.pictureSources(resolver.getPictureSources());
+    }
+    catch (Exception ex) {
+      log.warn("Error closing component property resolver.", ex);
     }
   }
 
@@ -92,10 +100,19 @@ final class MediaBuilderImpl implements MediaBuilder {
     }
   }
 
-  MediaBuilderImpl(String mediaRef, MediaHandlerImpl mediaHandler) {
-    this.resource = null;
+  MediaBuilderImpl(String mediaRef, Resource contextResource, MediaHandlerImpl mediaHandler,
+      @Nullable ComponentPropertyResolverFactory componentPropertyResolverFactory) {
+    this.resource = contextResource;
     this.mediaRef = mediaRef;
     this.mediaHandler = mediaHandler;
+
+    if (contextResource != null) {
+      resolveDefaultSettingsFromPolicyAndComponent(contextResource, componentPropertyResolverFactory);
+    }
+  }
+
+  MediaBuilderImpl(String mediaRef, MediaHandlerImpl mediaHandler) {
+    this(mediaRef, null, mediaHandler, null);
   }
 
   MediaBuilderImpl(MediaRequest mediaRequest, MediaHandlerImpl mediaHandler) {

--- a/media/src/main/java/io/wcm/handler/media/impl/MediaHandlerImpl.java
+++ b/media/src/main/java/io/wcm/handler/media/impl/MediaHandlerImpl.java
@@ -30,6 +30,7 @@ import org.apache.sling.models.annotations.injectorspecific.InjectionStrategy;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 import org.apache.sling.models.annotations.injectorspecific.Self;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import com.google.common.collect.ImmutableList;
 
@@ -85,6 +86,11 @@ public final class MediaHandlerImpl implements MediaHandler {
   @Override
   public @NotNull MediaBuilder get(String mediaRef) {
     return new MediaBuilderImpl(mediaRef, this);
+  }
+
+  @Override
+  public @NotNull MediaBuilder get(String mediaRef, @Nullable Resource contextResource) {
+    return new MediaBuilderImpl(mediaRef, contextResource, this, componentPropertyResolverFactory);
   }
 
   @Override

--- a/media/src/main/java/io/wcm/handler/media/package-info.java
+++ b/media/src/main/java/io/wcm/handler/media/package-info.java
@@ -20,5 +20,5 @@
 /**
  * Media Handler API.
  */
-@org.osgi.annotation.versioning.Version("1.9")
+@org.osgi.annotation.versioning.Version("1.10")
 package io.wcm.handler.media;

--- a/media/src/test/java/io/wcm/handler/media/impl/MediaHandlerImplTest.java
+++ b/media/src/test/java/io/wcm/handler/media/impl/MediaHandlerImplTest.java
@@ -224,6 +224,32 @@ class MediaHandlerImplTest {
   }
 
   @Test
+  void shouldResolveComponentPropertiesFromContextResourceWhenBuildingFromMediaRef() {
+    Resource component = context.create().resource("/apps/app1/components/comp1",
+        MediaNameConstants.PN_COMPONENT_MEDIA_FORMATS, new String[] { "home_stage", "home_teaser" },
+        MediaNameConstants.PN_COMPONENT_MEDIA_FORMATS_MANDATORY, new Boolean[] { true, false },
+        MediaNameConstants.PN_COMPONENT_MEDIA_AUTOCROP, true);
+
+    Resource resource = context.create().resource("/content/test",
+        "sling:resourceType", component.getPath());
+
+    String mediaRef = "/content/dummymedia/item1";
+
+    MediaHandler mediaHandler = AdaptTo.notNull(adaptable(), MediaHandler.class);
+    Media metadata = mediaHandler.get(mediaRef, resource).build();
+
+    MediaFormatOption[] mediaFormatOptions = metadata.getMediaRequest().getMediaArgs().getMediaFormatOptions();
+
+    assertEquals(2, mediaFormatOptions.length);
+    assertEquals(TestMediaFormats.HOME_STAGE, mediaFormatOptions[0].getMediaFormat());
+    assertTrue(mediaFormatOptions[0].isMandatory());
+    assertEquals(TestMediaFormats.HOME_TEASER, mediaFormatOptions[1].getMediaFormat());
+    assertFalse(mediaFormatOptions[1].isMandatory());
+
+    assertTrue(metadata.getMediaRequest().getMediaArgs().isAutoCrop());
+  }
+
+  @Test
   @SuppressWarnings("deprecation")
   void testComponentProperties_Legacy_SingleMandatoryFlag() {
     Resource component = context.create().resource("/apps/app1/components/comp1",


### PR DESCRIPTION
I have the usecase where my component does not store assets-references are in a resource, but dynamically retrieves them from somewhere else. I'd like to still be able to take advantage of the mechanism that resolves default settings from the policy and my component like when using MediaHandler.get(Resource resource).

I added MediaHandler.get(String mediaRef, Resource resource) which allows to build a media from its string while also resolving default settings from the component associated with the passed context resource like MediaHandler.get(Resource resource) does.

Of course I could resolve them on my own using a MediaComponentPropertyResolver and pass the values as MediaArgs to MediaHandler.get(String,MediaArgs), but it would be convenient to have it already in MediaHandler.
