### PR TITLE
Feature/whan 34 multi mediaformat responsive image

### DIFF
--- a/media/changes.xml
+++ b/media/changes.xml
@@ -30,6 +30,9 @@
       <action type="add" dev="mrozati" issue="WHAN-33">
         ResourceMedia: Add support for request attributes defining responsive image sizes. This can be either `imageSizes` and `widthOptions` (width + required flag), or `pictureSourceMediaFormat`, `pictureSourceMedia` and `pictureSourceWidths`.
       </action>
+      <action type="fix" dev="mrozati" issue="WHAN-34">
+        Support responsive images with multiple media formats and image widths.
+      </action>
     </release>
 
     <release version="1.8.2" date="2020-01-30">

--- a/media/src/main/java/io/wcm/handler/media/MediaNameConstants.java
+++ b/media/src/main/java/io/wcm/handler/media/MediaNameConstants.java
@@ -238,4 +238,10 @@ public final class MediaNameConstants {
   @Deprecated
   public static final @NotNull String NN_COMPONENT_MEDIA_RESPONSIVE_PICTURE_SOURCES = "wcmio:mediaRepsonsivePictureSources";
 
+  /**
+   * Media format property name for the parent media format. Parent media format is the original media format that
+   * is used to generate a width-based sub-media-format for responsive images.
+   */
+  public static final String MEDIAFORMAT_PROP_PARENT_MEDIA_FORMAT = "parentMediaFormat";
+
 }

--- a/media/src/main/java/io/wcm/handler/media/impl/MediaFormatResolver.java
+++ b/media/src/main/java/io/wcm/handler/media/impl/MediaFormatResolver.java
@@ -19,6 +19,7 @@
  */
 package io.wcm.handler.media.impl;
 
+import static io.wcm.handler.media.MediaNameConstants.MEDIAFORMAT_PROP_PARENT_MEDIA_FORMAT;
 import static org.apache.commons.lang3.ArrayUtils.isEmpty;
 
 import java.util.ArrayList;
@@ -168,7 +169,7 @@ final class MediaFormatResolver {
 
   private boolean resolveForImageSizes(MediaArgs mediaArgs, Map<String, MediaFormatOption> additionalMediaFormats) {
     ImageSizes imageSizes = mediaArgs.getImageSizes();
-    if (imageSizes == null || imageSizes.getWidthOptions() == null) {
+    if (imageSizes == null) {
       return true;
     }
 
@@ -207,7 +208,7 @@ final class MediaFormatResolver {
           .extensions(mediaFormat.getExtensions())
           .ratio(mediaFormat.getRatio())
           .width(widthOption.getWidth())
-          .property("parentMediaFormat", setParent ? mediaFormat : null)
+          .property(MEDIAFORMAT_PROP_PARENT_MEDIA_FORMAT, setParent ? mediaFormat : null)
           .build();
       additionalMediaFormats.put(widthMediaFormat.getName(), new MediaFormatOption(widthMediaFormat, widthOption.isMandatory()));
     }

--- a/media/src/main/java/io/wcm/handler/media/impl/MediaFormatResolver.java
+++ b/media/src/main/java/io/wcm/handler/media/impl/MediaFormatResolver.java
@@ -19,11 +19,14 @@
  */
 package io.wcm.handler.media.impl;
 
+import static org.apache.commons.lang3.ArrayUtils.isEmpty;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -165,25 +168,19 @@ final class MediaFormatResolver {
 
   private boolean resolveForImageSizes(MediaArgs mediaArgs, Map<String, MediaFormatOption> additionalMediaFormats) {
     ImageSizes imageSizes = mediaArgs.getImageSizes();
-    if (imageSizes == null) {
+    if (imageSizes == null || imageSizes.getWidthOptions() == null) {
       return true;
     }
-    MediaFormat primaryMediaFormat = getFirstMediaFormat(mediaArgs);
-    if (primaryMediaFormat == null) {
+
+    if (isEmpty(mediaArgs.getMediaFormats())) {
       log.warn("No media format with ratio given - unable to fulfill resolve image sizes.");
       return false;
     }
-    generateMediaFormatsForWidths(additionalMediaFormats, primaryMediaFormat, imageSizes.getWidthOptions());
-    return true;
-  }
 
-  private MediaFormat getFirstMediaFormat(MediaArgs mediaArgs) {
-    if (mediaArgs.getMediaFormats() != null) {
-      for (MediaFormat mediaFormat : mediaArgs.getMediaFormats()) {
-        return mediaFormat;
-      }
-    }
-    return null;
+    Arrays.stream(mediaArgs.getMediaFormats())
+        .filter(Objects::nonNull)
+        .forEach(mediaFormat -> generateMediaFormatsForWidths(additionalMediaFormats, mediaFormat, imageSizes.getWidthOptions()));
+    return true;
   }
 
   private boolean resolveForResponsivePictureSources(MediaArgs mediaArgs, Map<String, MediaFormatOption> additionalMediaFormats) {
@@ -209,6 +206,7 @@ final class MediaFormatResolver {
           .extensions(mediaFormat.getExtensions())
           .ratio(mediaFormat.getRatio())
           .width(widthOption.getWidth())
+          .property("responsiveMediaFormat", true)
           .build();
       additionalMediaFormats.put(widthMediaFormat.getName(), new MediaFormatOption(widthMediaFormat, widthOption.isMandatory()));
     }

--- a/media/src/main/java/io/wcm/handler/media/impl/MediaFormatResolver.java
+++ b/media/src/main/java/io/wcm/handler/media/impl/MediaFormatResolver.java
@@ -172,14 +172,15 @@ final class MediaFormatResolver {
       return true;
     }
 
-    if (isEmpty(mediaArgs.getMediaFormats())) {
+    final MediaFormat[] mediaFormats = mediaArgs.getMediaFormats();
+    if (isEmpty(mediaFormats)) {
       log.warn("No media format with ratio given - unable to fulfill resolve image sizes.");
       return false;
     }
 
-    Arrays.stream(mediaArgs.getMediaFormats())
+    Arrays.stream(mediaFormats)
         .filter(Objects::nonNull)
-        .forEach(mediaFormat -> generateMediaFormatsForWidths(additionalMediaFormats, mediaFormat, imageSizes.getWidthOptions()));
+        .forEach(mediaFormat -> generateMediaFormatsForWidths(additionalMediaFormats, mediaFormat, true, imageSizes.getWidthOptions()));
     return true;
   }
 
@@ -189,13 +190,13 @@ final class MediaFormatResolver {
       return true;
     }
     for (PictureSource pictureSource : pictureSources) {
-      generateMediaFormatsForWidths(additionalMediaFormats, pictureSource.getMediaFormat(), pictureSource.getWidthOptions());
+      generateMediaFormatsForWidths(additionalMediaFormats, pictureSource.getMediaFormat(), false, pictureSource.getWidthOptions());
     }
     return true;
   }
 
   private void generateMediaFormatsForWidths(@NotNull Map<String, MediaFormatOption> additionalMediaFormats,
-      @Nullable MediaFormat mediaFormat, @NotNull WidthOption @Nullable... widthOptions) {
+      @Nullable MediaFormat mediaFormat, boolean setParent, @NotNull WidthOption @Nullable... widthOptions) {
     if (mediaFormat == null || widthOptions == null) {
       return;
     }
@@ -206,7 +207,7 @@ final class MediaFormatResolver {
           .extensions(mediaFormat.getExtensions())
           .ratio(mediaFormat.getRatio())
           .width(widthOption.getWidth())
-          .property("responsiveMediaFormat", true)
+          .property("parentMediaFormat", setParent ? mediaFormat : null)
           .build();
       additionalMediaFormats.put(widthMediaFormat.getName(), new MediaFormatOption(widthMediaFormat, widthOption.isMandatory()));
     }

--- a/media/src/main/java/io/wcm/handler/media/markup/SimpleImageMediaMarkupBuilder.java
+++ b/media/src/main/java/io/wcm/handler/media/markup/SimpleImageMediaMarkupBuilder.java
@@ -21,6 +21,7 @@ package io.wcm.handler.media.markup;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
@@ -295,18 +296,16 @@ public class SimpleImageMediaMarkupBuilder extends AbstractImageMediaMarkupBuild
   }
 
   /**
-   * Get first media format from the media formats of the media args that has a ratio set.
+   * Get first media format from the resolved media renditions.
    * @param media Media
    * @return Media format or null if none found
    */
   protected final @Nullable MediaFormat getFirstMediaFormat(@NotNull Media media) {
-    MediaFormat[] mediaFormats = media.getMediaRequest().getMediaArgs().getMediaFormats();
-    if (mediaFormats != null) {
-      for (MediaFormat mediaFormat : mediaFormats) {
-        return mediaFormat;
-      }
-    }
-    return null;
+    return media.getRenditions().stream()
+        .map(Rendition::getMediaFormat)
+        .filter(Objects::nonNull)
+        .findFirst()
+        .orElseGet(null);
   }
 
   /**

--- a/media/src/main/java/io/wcm/handler/media/spi/MediaSource.java
+++ b/media/src/main/java/io/wcm/handler/media/spi/MediaSource.java
@@ -391,7 +391,7 @@ public abstract class MediaSource {
    * @return true if for all mandatory or for at least one media formats a rendition could be found.
    */
   private boolean resolveAllRenditions(@NotNull Media media, @NotNull Asset asset, @NotNull final MediaArgs mediaArgs) {
-    boolean anyResolved;
+    boolean anyResolved = false;
     boolean allMandatoryResolved;
     final List<Rendition> resolvedRenditions = new ArrayList<>();
 
@@ -410,10 +410,9 @@ public abstract class MediaSource {
       }
     }
 
-    anyResolved = CollectionUtils.isNotEmpty(resolvedRenditions);
-
     media.setRenditions(resolvedRenditions);
     if (!resolvedRenditions.isEmpty()) {
+      anyResolved = true;
       media.setUrl(resolvedRenditions.get(0).getUrl());
     }
     return anyResolved && allMandatoryResolved;

--- a/media/src/main/java/io/wcm/handler/media/spi/MediaSource.java
+++ b/media/src/main/java/io/wcm/handler/media/spi/MediaSource.java
@@ -19,6 +19,7 @@
  */
 package io.wcm.handler.media.spi;
 
+import static io.wcm.handler.media.MediaNameConstants.MEDIAFORMAT_PROP_PARENT_MEDIA_FORMAT;
 import static io.wcm.handler.media.impl.ImageTransformation.isValidRotation;
 
 import java.util.ArrayList;
@@ -353,8 +354,7 @@ public abstract class MediaSource {
   protected final boolean resolveRenditions(Media media, Asset asset, MediaArgs mediaArgs) {
     boolean anyMandatory = mediaArgs.getMediaFormatOptions() != null
         && Arrays.stream(mediaArgs.getMediaFormatOptions())
-        .filter(MediaFormatOption::isMandatory)
-        .findFirst().isPresent();
+        .anyMatch(MediaFormatOption::isMandatory);
     if (mediaArgs.getMediaFormats() != null && mediaArgs.getMediaFormats().length > 1
         && (anyMandatory || mediaArgs.getImageSizes() != null || mediaArgs.getPictureSources() != null)) {
       return resolveAllRenditions(media, asset, mediaArgs);
@@ -391,8 +391,8 @@ public abstract class MediaSource {
    * @return true if for all mandatory or for at least one media formats a rendition could be found.
    */
   private boolean resolveAllRenditions(@NotNull Media media, @NotNull Asset asset, @NotNull final MediaArgs mediaArgs) {
-    boolean allMandatoryResolved = true;
-    boolean anyResolved = false;
+    boolean anyResolved;
+    boolean allMandatoryResolved;
     final List<Rendition> resolvedRenditions = new ArrayList<>();
 
     List<MediaFormatOption> parentMediaFormatOptions = getParentMediaFormats(mediaArgs);
@@ -464,8 +464,11 @@ public abstract class MediaSource {
   }
 
   @Nullable
-  private MediaFormat getParentMediaFormat(@NotNull MediaFormat mediaFormat) {
-    return mediaFormat.getProperties().get("parentMediaFormat", MediaFormat.class);
+  private MediaFormat getParentMediaFormat(@Nullable MediaFormat mediaFormat) {
+    if (mediaFormat == null) {
+      return null;
+    }
+    return mediaFormat.getProperties().get(MEDIAFORMAT_PROP_PARENT_MEDIA_FORMAT, MediaFormat.class);
   }
 
 }

--- a/media/src/main/java/io/wcm/handler/media/spi/MediaSource.java
+++ b/media/src/main/java/io/wcm/handler/media/spi/MediaSource.java
@@ -25,7 +25,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.apache.commons.collections.CollectionUtils;
@@ -63,8 +62,6 @@ import io.wcm.handler.media.imagemap.ImageMapParser;
  */
 @ConsumerType
 public abstract class MediaSource {
-
-  private static final Pattern RESPONSIVE_MEDIA_FORMAT_PATTERN = Pattern.compile("^(.+)___\\d+$");
 
   /**
    * @return Media source ID

--- a/media/src/test/java/io/wcm/handler/media/impl/MediaFormatResolverTest.java
+++ b/media/src/test/java/io/wcm/handler/media/impl/MediaFormatResolverTest.java
@@ -138,6 +138,42 @@ class MediaFormatResolverTest {
   }
 
   @Test
+  void testImageSizes_MultipleMediaFormats() {
+    MediaArgs mediaArgs = new MediaArgs()
+        .mediaFormats(RATIO, RATIO2)
+        .imageSizes(new ImageSizes("size1", 10, 20));
+
+    assertTrue(underTest.resolve(mediaArgs));
+
+    MediaFormatOption[] mediaFormatOptions = mediaArgs.getMediaFormatOptions();
+    assertEquals(6, mediaFormatOptions.length);
+    assertEquals(RATIO, mediaFormatOptions[0].getMediaFormat());
+    assertEquals(RATIO2, mediaFormatOptions[1].getMediaFormat());
+    assertResponsiveMediaFormat(RATIO, 10, true, mediaFormatOptions[2]);
+    assertResponsiveMediaFormat(RATIO, 20, true, mediaFormatOptions[3]);
+    assertResponsiveMediaFormat(RATIO2, 10, true, mediaFormatOptions[4]);
+    assertResponsiveMediaFormat(RATIO2, 20, true, mediaFormatOptions[5]);
+  }
+
+  @Test
+  void testImageSizes_MultipleMediaFormats_MixedMandatory() {
+    MediaArgs mediaArgs = new MediaArgs()
+        .mediaFormats(RATIO, RATIO2)
+        .imageSizes(new ImageSizes("size1", new WidthOption(10, true), new WidthOption(20, false)));
+
+    assertTrue(underTest.resolve(mediaArgs));
+
+    MediaFormatOption[] mediaFormatOptions = mediaArgs.getMediaFormatOptions();
+    assertEquals(6, mediaFormatOptions.length);
+    assertEquals(RATIO, mediaFormatOptions[0].getMediaFormat());
+    assertEquals(RATIO2, mediaFormatOptions[1].getMediaFormat());
+    assertResponsiveMediaFormat(RATIO, 10, true, mediaFormatOptions[2]);
+    assertResponsiveMediaFormat(RATIO, 20, false, mediaFormatOptions[3]);
+    assertResponsiveMediaFormat(RATIO2, 10, true, mediaFormatOptions[4]);
+    assertResponsiveMediaFormat(RATIO2, 20, false, mediaFormatOptions[5]);
+  }
+
+  @Test
   void testImageSizes_NoRatioMediaFormat() {
     MediaArgs mediaArgs = new MediaArgs()
         .mediaFormat(FIXEDWIDTH_UNCONSTRAINED)

--- a/media/src/test/java/io/wcm/handler/media/impl/MediaFormatResolverTest.java
+++ b/media/src/test/java/io/wcm/handler/media/impl/MediaFormatResolverTest.java
@@ -189,6 +189,14 @@ class MediaFormatResolverTest {
   }
 
   @Test
+  void testImageSizes_NoMediaFormat() {
+    MediaArgs mediaArgs = new MediaArgs()
+        .imageSizes(new ImageSizes("sizes", 10, 20));
+
+    assertFalse(underTest.resolve(mediaArgs));
+  }
+
+  @Test
   void testPictureSources_DifferentRatio() {
     MediaArgs mediaArgs = new MediaArgs()
         .mediaFormat(RATIO)
@@ -265,6 +273,32 @@ class MediaFormatResolverTest {
     assertResponsiveMediaFormat(RATIO, 20, true, mediaFormatOptions[1]);
     assertResponsiveMediaFormat(RATIO, 30, true, mediaFormatOptions[2]);
     assertResponsiveMediaFormat(RATIO, 10, true, mediaFormatOptions[3]);
+  }
+
+  @Test
+  void testPictureSources_NoWidths() {
+    MediaArgs mediaArgs = new MediaArgs()
+        .mediaFormat(RATIO)
+        .pictureSources(new PictureSource[] {
+            new PictureSource(RATIO).media("media1")
+        });
+
+    assertTrue(underTest.resolve(mediaArgs));
+
+    MediaFormatOption[] mediaFormatOptions = mediaArgs.getMediaFormatOptions();
+    assertEquals(1, mediaFormatOptions.length);
+    assertEquals(RATIO, mediaFormatOptions[0].getMediaFormat());
+  }
+
+  @Test
+  void testPictureSources_InvalidMediaFormatName() {
+    MediaArgs mediaArgs = new MediaArgs()
+        .mediaFormat(RATIO)
+        .pictureSources(new PictureSource[] {
+            new PictureSource("invalid-format-name").media("media1")
+        });
+
+    assertFalse(underTest.resolve(mediaArgs));
   }
 
   @SuppressWarnings("null")

--- a/media/src/test/java/io/wcm/handler/media/impl/MediaHandlerImplTest.java
+++ b/media/src/test/java/io/wcm/handler/media/impl/MediaHandlerImplTest.java
@@ -34,6 +34,7 @@ import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.adapter.Adaptable;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.osgi.framework.Constants;
@@ -335,7 +336,7 @@ class MediaHandlerImplTest {
   })
   public static class TestMediaSource extends MediaSource {
 
-    @Override
+    @Override @NotNull
     public String getId() {
       return "dummy";
     }
@@ -350,8 +351,8 @@ class MediaHandlerImplTest {
       return MediaNameConstants.PN_MEDIA_REF;
     }
 
-    @Override
-    public Media resolveMedia(Media media) {
+    @Override @NotNull
+    public Media resolveMedia(@NotNull Media media) {
       if (media.getMediaRequest().getMediaArgs().isDownload()) {
         String mediaUrl = media.getMediaRequest().getMediaRef();
         media.setUrl("http://xyz" + mediaUrl + ".pdf");
@@ -365,7 +366,7 @@ class MediaHandlerImplTest {
     }
 
     @Override
-    public void enableMediaDrop(HtmlElement<?> element, MediaRequest mediaRequest) {
+    public void enableMediaDrop(@NotNull HtmlElement<?> element, @NotNull MediaRequest mediaRequest) {
       // not supported
     }
 

--- a/media/src/test/java/io/wcm/handler/media/markup/SimpleImageMediaMarkupBuilderTest.java
+++ b/media/src/test/java/io/wcm/handler/media/markup/SimpleImageMediaMarkupBuilderTest.java
@@ -406,7 +406,7 @@ class SimpleImageMediaMarkupBuilderTest {
   void testIsValidMedia_Image() {
     MediaMarkupBuilder builder = AdaptTo.notNull(context.request(), SimpleImageMediaMarkupBuilder.class);
 
-    assertFalse(builder.isValidMedia(null)); // FIXME: the parameter 'element' has @NotNull annotation and cannot be null
+    assertFalse(builder.isValidMedia(null)); // backward compatibility null check
     assertFalse(builder.isValidMedia(new Image()));
     assertTrue(builder.isValidMedia(new Image("/any/path.gif")));
     assertFalse(builder.isValidMedia(new Image(MediaMarkupBuilder.DUMMY_IMAGE).setCssClass(MediaNameConstants.CSS_DUMMYIMAGE)));
@@ -416,7 +416,7 @@ class SimpleImageMediaMarkupBuilderTest {
   void testIsValidMedia_Picture() {
     MediaMarkupBuilder builder = AdaptTo.notNull(context.request(), SimpleImageMediaMarkupBuilder.class);
 
-    assertFalse(builder.isValidMedia(null)); // FIXME: the parameter 'element' has @NotNull annotation and cannot be null
+    assertFalse(builder.isValidMedia(null));  // backward compatibility null check
     assertFalse(builder.isValidMedia(new Picture()));
 
     Picture picture = new Picture();

--- a/media/src/test/java/io/wcm/handler/media/markup/SimpleImageMediaMarkupBuilderTest.java
+++ b/media/src/test/java/io/wcm/handler/media/markup/SimpleImageMediaMarkupBuilderTest.java
@@ -384,7 +384,7 @@ class SimpleImageMediaMarkupBuilderTest {
   void testIsValidMedia_Image() {
     MediaMarkupBuilder builder = AdaptTo.notNull(context.request(), SimpleImageMediaMarkupBuilder.class);
 
-    assertFalse(builder.isValidMedia(null));
+    assertFalse(builder.isValidMedia(null)); // FIXME: the parameter 'element' has @NotNull annotation and cannot be null
     assertFalse(builder.isValidMedia(new Image()));
     assertTrue(builder.isValidMedia(new Image("/any/path.gif")));
     assertFalse(builder.isValidMedia(new Image(MediaMarkupBuilder.DUMMY_IMAGE).setCssClass(MediaNameConstants.CSS_DUMMYIMAGE)));
@@ -394,7 +394,7 @@ class SimpleImageMediaMarkupBuilderTest {
   void testIsValidMedia_Picture() {
     MediaMarkupBuilder builder = AdaptTo.notNull(context.request(), SimpleImageMediaMarkupBuilder.class);
 
-    assertFalse(builder.isValidMedia(null));
+    assertFalse(builder.isValidMedia(null)); // FIXME: the parameter 'element' has @NotNull annotation and cannot be null
     assertFalse(builder.isValidMedia(new Picture()));
 
     Picture picture = new Picture();
@@ -412,6 +412,7 @@ class SimpleImageMediaMarkupBuilderTest {
     when(r.getHeight()).thenReturn(Math.round(width / mediaFormat.getRatio()));
     when(r.getRatio()).thenReturn(mediaFormat.getRatio());
     when(r.getUrl()).thenReturn("/media/dummy." + width + ".png");
+    when(r.getMediaFormat()).thenReturn(mediaFormat);
     return r;
   }
 

--- a/media/src/test/java/io/wcm/handler/media/markup/SimpleImageMediaMarkupBuilderTest.java
+++ b/media/src/test/java/io/wcm/handler/media/markup/SimpleImageMediaMarkupBuilderTest.java
@@ -214,6 +214,28 @@ class SimpleImageMediaMarkupBuilderTest {
   }
 
   @Test
+  void testBuild_ImageSizes_MultipleMediaFormats() {
+    MediaMarkupBuilder builder = AdaptTo.notNull(context.request(), SimpleImageMediaMarkupBuilder.class);
+
+    MediaRequest mediaRequest = new MediaRequest("/media/dummy", new MediaArgs());
+    mediaRequest.getMediaArgs().mediaFormats(RATIO2, RATIO); // <- only second format resolves
+    mediaRequest.getMediaArgs().imageSizes(new ImageSizes("sizes1", 64, 32, 16));
+    mediaRequest.getMediaArgs().property("custom-property", "value1");
+    Media media = new Media(mediaSource, mediaRequest);
+    media.setAsset(asset);
+    media.setRenditions(ImmutableList.of(rendition(RATIO, 128), rendition(RATIO, 64), rendition(RATIO, 16)));
+
+    HtmlElement<?> element = builder.build(media);
+    assertTrue(element instanceof Image);
+    assertEquals("/media/dummy.128.png", element.getAttributeValue("src"));
+    assertNull(element.getAttributeValue("width"));
+    assertNull(element.getAttributeValue("height"));
+    assertEquals("sizes1", element.getAttributeValue("sizes"));
+    assertEquals("/media/dummy.64.png 64w, /media/dummy.16.png 16w", element.getAttributeValue("srcset"));
+    assertEquals("value1", element.getAttributeValue("custom-property"));
+  }
+
+  @Test
   void testBuild_ImageSizes_NoRatio() {
     MediaMarkupBuilder builder = AdaptTo.notNull(context.request(), SimpleImageMediaMarkupBuilder.class);
 

--- a/media/src/test/java/io/wcm/handler/mediasource/dam/DamMediaSourceTest.java
+++ b/media/src/test/java/io/wcm/handler/mediasource/dam/DamMediaSourceTest.java
@@ -825,7 +825,7 @@ class DamMediaSourceTest extends AbstractDamTest {
   @Test
   void testMultipleMediaFormats_ImageSizes() {
     Media media = mediaHandler().get(MEDIAITEM_PATH_16_10)
-        .mediaFormats(RATIO, RATIO2)
+        .mediaFormats(RATIO2, RATIO) // <- only second media format matches
         .imageSizes("sizes", 160, 320)
         .build();
 

--- a/media/src/test/java/io/wcm/handler/mediasource/dam/DamMediaSourceTest.java
+++ b/media/src/test/java/io/wcm/handler/mediasource/dam/DamMediaSourceTest.java
@@ -26,6 +26,7 @@ import static io.wcm.handler.media.testcontext.DummyMediaFormats.FIXEDHEIGHT_UNC
 import static io.wcm.handler.media.testcontext.DummyMediaFormats.MATERIAL_TILE;
 import static io.wcm.handler.media.testcontext.DummyMediaFormats.PRODUCT_CUTOUT_LARGE;
 import static io.wcm.handler.media.testcontext.DummyMediaFormats.RATIO;
+import static io.wcm.handler.media.testcontext.DummyMediaFormats.RATIO2;
 import static io.wcm.handler.media.testcontext.DummyMediaFormats.SHOWROOM_CONTROLS_SCALE1;
 import static io.wcm.handler.media.testcontext.DummyMediaFormats.VIDEO_2COL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -818,6 +819,52 @@ class DamMediaSourceTest extends AbstractDamTest {
 
     MediaFormat mediaFormat2 = rendition2.getMediaFormat();
     assertEquals(FIXEDHEIGHT_UNCONSTRAINED.getLabel(), mediaFormat2.getLabel());
+    assertEquals(320, mediaFormat2.getWidth());
+  }
+
+  @Test
+  void testMultipleMediaFormats_ImageSizes() {
+    Media media = mediaHandler().get(MEDIAITEM_PATH_16_10)
+        .mediaFormats(RATIO, RATIO2)
+        .imageSizes("sizes", 160, 320)
+        .build();
+
+    assertTrue(media.isValid(), "valid?");
+    assertNotNull(media.getAsset(), "asset?");
+    assertEquals(3, media.getRenditions().size(), "renditions");
+    List<Rendition> renditions = ImmutableList.copyOf(media.getRenditions());
+
+    Rendition rendition0 = renditions.get(0);
+    assertEquals("/content/dam/test/sixteen-ten.jpg/_jcr_content/renditions/original./sixteen-ten.jpg",
+        rendition0.getUrl(), "rendition.mediaUrl.1");
+    assertEquals(1600, rendition0.getWidth());
+    assertEquals(1000, rendition0.getHeight());
+    assertEquals(160d / 100d, rendition0.getRatio(), 0.0001);
+
+    MediaFormat mediaFormat0 = rendition0.getMediaFormat();
+    assertEquals(RATIO.getName(), mediaFormat0.getName());
+
+    Rendition rendition1 = renditions.get(1);
+    assertEquals("/content/dam/test/sixteen-ten.jpg/_jcr_content/renditions/original.image_file.160.100.file/sixteen-ten.jpg",
+        rendition1.getUrl(), "rendition.mediaUrl.2");
+    assertEquals(160, rendition1.getWidth());
+    assertEquals(100, rendition1.getHeight());
+    assertEquals(160d / 100d, rendition1.getRatio(), 0.0001);
+
+    MediaFormat mediaFormat1 = rendition1.getMediaFormat();
+    assertEquals(RATIO.getLabel(), mediaFormat1.getLabel());
+    assertEquals(RATIO.getRatio(), mediaFormat1.getRatio(), 0.001d);
+    assertEquals(160, mediaFormat1.getWidth());
+
+    Rendition rendition2 = renditions.get(2);
+    assertEquals("/content/dam/test/sixteen-ten.jpg/_jcr_content/renditions/original.image_file.320.200.file/sixteen-ten.jpg",
+        rendition2.getUrl(), "rendition.mediaUrl.3");
+    assertEquals(320, rendition2.getWidth());
+    assertEquals(200, rendition2.getHeight());
+
+    MediaFormat mediaFormat2 = rendition2.getMediaFormat();
+    assertEquals(RATIO.getLabel(), mediaFormat2.getLabel());
+    assertEquals(RATIO.getRatio(), mediaFormat2.getRatio(), 0.001d);
     assertEquals(320, mediaFormat2.getWidth());
   }
 


### PR DESCRIPTION
`MediaFormatResolver`: generate additional width-based mediaformats for all available media formats, not only for the primary one
`MediaSource`: resolve additional width-based mediaformats only when the parent (original) mediaformat could be resolved to a rendition. otherwise ignore width-based formats even when they are mandatory