### PR TITLE
mediaPlaceholder.html translate the component's jcr:title

### DIFF
--- a/media/changes.xml
+++ b/media/changes.xml
@@ -24,6 +24,9 @@
   <body>
 
     <release version="1.9.0" date="not released">
+      <action type="fix" dev="mceruti">
+        mediaPlaceholder.html translate the component's jcr:title so the component's i18ned title is displayed. 
+      </action>
       <action type="add" dev="mceruti">
         MediaHandler: Adds MediaHandler.get(String, Resource) that allows building a media from it's path while still looking up policy/component level settings from the given context resource, like it is done when building a media using MediaHandler.get(Resource). Requires the ComponentPropertyResolverFactory to work and be <![CDATA[<a href="https://wcm.io/wcm/commons/configuration.html">configured</a>]]> properly.
       </action>

--- a/media/src/main/webapp/app-root/components/placeholder/mediaPlaceholder.html
+++ b/media/src/main/webapp/app-root/components/placeholder/mediaPlaceholder.html
@@ -30,7 +30,7 @@
     data-sly-use.mediaPlaceholder="${'io.wcm.handler.media.ui.MediaPlaceholder' @ media=media, classAppend=classAppend}">
   <div data-sly-test="${(wcmmode.edit || wcmmode.preview) && isEmpty}"
        class="cq-placeholder ${mediaPlaceholder.classAppend}"
-       data-emptytext="${component.properties.jcr:title}
+       data-emptytext="${component.properties.jcr:title @ i18n}
          ${mediaPlaceholder.mediaInvalidReason && '-'}
          ${mediaPlaceholder.mediaInvalidReason @ i18n}"></div>
 </sly>


### PR DESCRIPTION
I've been using the mediaPlaceholder.html template for a component that features an i18n-key as `jcr:title`. It is not translated and the key is displayed. I propose to simply apply @ i18n .