### PR TITLE
WHAN-36 ResourceMedia: support dynamic custom properties from HTL

### DIFF
--- a/media/changes.xml
+++ b/media/changes.xml
@@ -36,6 +36,9 @@
       <action type="fix" dev="bkalbitz" issue="WHAN-35">
         Avoid duplicated storing for fileReference in File Upload component.
       </action>
+      <action type="add" dev="mrozati" issue="WHAN-36">
+        ResourceMedia: support dynamic custom properties from HTL
+      </action>
     </release>
 
     <release version="1.8.2" date="2020-01-30">

--- a/media/src/main/java/io/wcm/handler/media/MediaArgs.java
+++ b/media/src/main/java/io/wcm/handler/media/MediaArgs.java
@@ -618,6 +618,7 @@ public final class MediaArgs implements Cloneable {
    * Custom properties that my be used by application-specific markup builders or processors.
    * @return Value map
    */
+  @NotNull
   public ValueMap getProperties() {
     if (this.properties == null) {
       this.properties = new ValueMapDecorator(new HashMap<String, Object>());

--- a/media/src/main/java/io/wcm/handler/media/ui/ResourceMedia.java
+++ b/media/src/main/java/io/wcm/handler/media/ui/ResourceMedia.java
@@ -62,6 +62,8 @@ import io.wcm.handler.media.format.MediaFormatHandler;
  * <li><code>cropProperty</code>: Name of the property which contains the cropping parameters</li>
  * <li><code>rotationProperty</code>: Name of the property which contains the rotation parameter</li>
  * <li><code>cssClass</code>: CSS classes to be applied on the generated media element (most cases img element)</li>
+ * <li><code>property:&lt;propertyname&gt;</code>: Custom properties for MediaArgs can be added with the name prefix {@value #RA_PROPERTY_PREFIX},
+ * e.g. {@literal "property:myprop1"="value1"} which adds property {@literal "myprop1"} to the the MediaArgs. Custom properties with null value will be ignored.</li>
  * </ul>
  */
 @Model(adaptables = SlingHttpServletRequest.class)
@@ -70,12 +72,12 @@ public class ResourceMedia {
   /**
    * Name prefix for request attributes that will be put into the media builder properties
    */
-  private static final String REQUEST_ATTRIBUTE_PREFIX = "mediaProp:";
+  private static final String RA_PROPERTY_PREFIX = "property:";
 
   /**
-   * Regex pattern that matches request attribute names with the prefix {@value REQUEST_ATTRIBUTE_PREFIX}
+   * Regex pattern that matches request attribute names with the prefix {@value #RA_PROPERTY_PREFIX}
    */
-  private static final Pattern REQUEST_ATTRIBUTE_PATTERN = Pattern.compile("^" + REQUEST_ATTRIBUTE_PREFIX + ".+$");
+  private static final Pattern REQUEST_ATTRIBUTE_PATTERN = Pattern.compile("^" + RA_PROPERTY_PREFIX + ".+$");
 
   /**
    * Optional: Media format to be used.
@@ -198,7 +200,7 @@ public class ResourceMedia {
   }
 
   /**
-   * Puts all request attributes that their name starts with the prefix {@value #REQUEST_ATTRIBUTE_PREFIX} into the properties of the media builder
+   * Puts all request attributes that their name starts with the prefix {@value #RA_PROPERTY_PREFIX} into the properties of the media builder
    * @param builder Media builder
    */
   private void setCustomProperties(MediaBuilder builder) {
@@ -207,7 +209,7 @@ public class ResourceMedia {
   }
 
   /**
-   * Gathers all request attributes whose name begins with the prefix {@value #REQUEST_ATTRIBUTE_PREFIX}, strips the prefix to get the property name
+   * Gathers all request attributes whose name begins with the prefix {@value #RA_PROPERTY_PREFIX}, strips the prefix to get the property name
    * and returns a map of property name to request attribute value
    * @return map of custom properties
    */
@@ -242,7 +244,7 @@ public class ResourceMedia {
 
   @NotNull
   private String toPropertyName(@NotNull String requestAttributeName) {
-    return StringUtils.substringAfter(requestAttributeName, REQUEST_ATTRIBUTE_PREFIX);
+    return StringUtils.substringAfter(requestAttributeName, RA_PROPERTY_PREFIX);
   }
 
   /**

--- a/media/src/main/java/io/wcm/handler/media/ui/ResourceMedia.java
+++ b/media/src/main/java/io/wcm/handler/media/ui/ResourceMedia.java
@@ -77,7 +77,7 @@ public class ResourceMedia {
   /**
    * Regex pattern that matches request attribute names with the prefix {@value #RA_PROPERTY_PREFIX}
    */
-  private static final Pattern REQUEST_ATTRIBUTE_PATTERN = Pattern.compile("^" + RA_PROPERTY_PREFIX + ".+$");
+  private static final Pattern PROPERTY_NAME_PATTERN = Pattern.compile("^" + RA_PROPERTY_PREFIX + ".+$");
 
   /**
    * Optional: Media format to be used.
@@ -235,7 +235,7 @@ public class ResourceMedia {
   }
 
   private boolean isMediaPropAttribute(@NotNull String requestAttributeName) {
-    return REQUEST_ATTRIBUTE_PATTERN.matcher(requestAttributeName).matches();
+    return PROPERTY_NAME_PATTERN.matcher(requestAttributeName).matches();
   }
 
   private boolean attributeValueIsNotNull(String attributeName) {

--- a/media/src/main/java/io/wcm/handler/media/ui/ResourceMedia.java
+++ b/media/src/main/java/io/wcm/handler/media/ui/ResourceMedia.java
@@ -70,7 +70,7 @@ public class ResourceMedia {
   /**
    * Name prefix for request attributes that will be put into the media builder properties
    */
-  public static final String REQUEST_ATTRIBUTE_PREFIX = "mediaProp:";
+  private static final String REQUEST_ATTRIBUTE_PREFIX = "mediaProp:";
 
   /**
    * Regex pattern that matches request attribute names with the prefix {@value REQUEST_ATTRIBUTE_PREFIX}

--- a/media/src/test/java/io/wcm/handler/media/ui/ResourceMediaTest.java
+++ b/media/src/test/java/io/wcm/handler/media/ui/ResourceMediaTest.java
@@ -27,12 +27,16 @@ import static io.wcm.handler.media.testcontext.DummyMediaFormats.SHOWROOM_CAMPAI
 import static org.apache.sling.api.resource.ResourceResolver.PROPERTY_RESOURCE_TYPE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ValueMap;
 import org.jdom2.Element;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -191,6 +195,32 @@ class ResourceMediaTest {
     // validate img
     HtmlElement<?> img = (HtmlElement<?>)picture.getChild("img");
     assertTrue(img instanceof io.wcm.handler.commons.dom.Image);
+  }
+
+  @Test
+  void testWithCustomProperties() {
+    context.request().setAttribute("mediaProp:prop1", true);
+    context.request().setAttribute("mediaProp:prop2", "value2");
+    context.request().setAttribute("mediaProp:prop3", new String[]{"array-item1", "array-item2"});
+    context.request().setAttribute("mediaProp:prop4", null);
+    context.request().setAttribute("mediaProp:prop5", new HashMap<>());
+    context.request().setAttribute("mediaProp:", "invalid-prop--no-name");
+    context.request().setAttribute("nonRelevantAttribute", "some-value");
+
+    ResourceMedia underTest = context.request().adaptTo(ResourceMedia.class);
+
+    assertNotNull(underTest);
+    assertTrue(underTest.isValid());
+
+    final ValueMap properties = underTest.getMetadata().getMediaRequest().getMediaArgs().getProperties();
+    assertEquals(4, properties.size());
+    assertEquals(true, properties.get("prop1"));
+    assertEquals("value2", properties.get("prop2"));
+    assertTrue(properties.get("prop3") instanceof String[]);
+    assertEquals(2, properties.get("prop3", new String[0]).length);
+    assertEquals("array-item2", properties.get("prop3", new String[0])[1]);
+    assertEquals("null-value--is-ignored", properties.get("prop4", "null-value--is-ignored"));
+    assertTrue(properties.get("prop5") instanceof Map);
   }
 
 }

--- a/media/src/test/java/io/wcm/handler/media/ui/ResourceMediaTest.java
+++ b/media/src/test/java/io/wcm/handler/media/ui/ResourceMediaTest.java
@@ -199,12 +199,12 @@ class ResourceMediaTest {
 
   @Test
   void testWithCustomProperties() {
-    context.request().setAttribute("mediaProp:prop1", true);
-    context.request().setAttribute("mediaProp:prop2", "value2");
-    context.request().setAttribute("mediaProp:prop3", new String[]{"array-item1", "array-item2"});
-    context.request().setAttribute("mediaProp:prop4", null);
-    context.request().setAttribute("mediaProp:prop5", new HashMap<>());
-    context.request().setAttribute("mediaProp:", "invalid-prop--no-name");
+    context.request().setAttribute("property:prop1", true);
+    context.request().setAttribute("property:prop2", "value2");
+    context.request().setAttribute("property:prop3", new String[]{"array-item1", "array-item2"});
+    context.request().setAttribute("property:prop4", null);
+    context.request().setAttribute("property:prop5", new HashMap<>());
+    context.request().setAttribute("property:", "invalid-prop--no-name");
     context.request().setAttribute("nonRelevantAttribute", "some-value");
 
     ResourceMedia underTest = context.request().adaptTo(ResourceMedia.class);


### PR DESCRIPTION
since there is currently no syntax for defining map literals in the HTL spec (https://github.com/adobe/htl-spec/issues/63), we retrieve request attributes whose name start with the prefix `mediaProp:` and put them into the media args properties.