### PR TITLE
resolve optional mediaformats more leniently

### DIFF
--- a/media/changes.xml
+++ b/media/changes.xml
@@ -27,6 +27,9 @@
       <action type="fix" dev="mrozati">
         SimpleImageMediaMarkupBuilder: fix NPE
       </action>
+      <action type="fix" dev="mrozati">
+        Media Handler: When optional media formats don't match any rendition, try to resolve their responsive child formats.
+      </action>
     </release>
 
     <release version="1.9.4" date="2020-08-26">

--- a/media/src/test/java/io/wcm/handler/media/format/MediaFormatHandlerTest.java
+++ b/media/src/test/java/io/wcm/handler/media/format/MediaFormatHandlerTest.java
@@ -39,6 +39,7 @@ import static io.wcm.handler.media.testcontext.DummyMediaFormats.NONFIXED_RAW;
 import static io.wcm.handler.media.testcontext.DummyMediaFormats.NONFIXED_SMALL;
 import static io.wcm.handler.media.testcontext.DummyMediaFormats.NONFIXED_TAB_FULLSIZE;
 import static io.wcm.handler.media.testcontext.DummyMediaFormats.NONFIXED_TAB_SMALL;
+import static io.wcm.handler.media.testcontext.DummyMediaFormats.NORATIO_LARGE_MINWIDTH;
 import static io.wcm.handler.media.testcontext.DummyMediaFormats.RATIO;
 import static io.wcm.handler.media.testcontext.DummyMediaFormats.SPECIAL_4COL;
 import static io.wcm.handler.media.testcontext.DummyMediaFormats.WALLPAPER;
@@ -170,7 +171,7 @@ class MediaFormatHandlerTest {
     Set<MediaFormat> matchingFormats = underTest.getSameBiggerMediaFormats(NONFIXED_BIG, true);
     Iterator<MediaFormat> iterator = matchingFormats.iterator();
 
-    assertEquals(5, matchingFormats.size());
+    assertEquals(6, matchingFormats.size());
 
     MediaFormat format1 = iterator.next();
     assertEquals(NONFIXED_RAW, format1);
@@ -186,6 +187,9 @@ class MediaFormatHandlerTest {
 
     MediaFormat format5 = iterator.next();
     assertEquals(NONFIXED_BIG, format5);
+
+    MediaFormat format6 = iterator.next();
+    assertEquals(NORATIO_LARGE_MINWIDTH, format6);
 
   }
 

--- a/media/src/test/java/io/wcm/handler/media/testcontext/DummyMediaFormats.java
+++ b/media/src/test/java/io/wcm/handler/media/testcontext/DummyMediaFormats.java
@@ -415,6 +415,13 @@ public final class DummyMediaFormats {
       .renditionGroup("/apps/test/renditiongroup/nonfixed")
       .ranking(205)
       .build();
+  public static final MediaFormat NORATIO_LARGE_MINWIDTH = create("noratio_large_minwidth")
+      .label("freehand (no ratio, large min width)")
+      .minWidth(2650)
+      .extensions("gif","jpg","jpeg","png")
+      .renditionGroup("/apps/test/renditiongroup/nonfixed")
+      .ranking(500)
+      .build();
 
   /* rendition group with fixed width  */
   public static final MediaFormat FIXEDWIDTH_188 = create("fixedwidth_188")


### PR DESCRIPTION
Media Handler: When optional media formats don't match any rendition try to resolve their responsive child formats.