### PR TITLE
Unique category for authoring dialog client libs.

### DIFF
--- a/link/src/main/webapp/app-root/clientlibs/authoring/dialog.json
+++ b/link/src/main/webapp/app-root/clientlibs/authoring/dialog.json
@@ -1,5 +1,8 @@
 {
   "jcr:primaryType":"cq:ClientLibraryFolder",
-  "categories":["cq.authoring.dialog"],
+  "categories":[
+    "wcm.io.authoring.dialog",
+    "cq.authoring.dialog"
+  ],
   "dependencies":["granite.jquery"]
 }

--- a/link/src/main/webapp/app-root/clientlibs/authoring/dialog.json
+++ b/link/src/main/webapp/app-root/clientlibs/authoring/dialog.json
@@ -1,8 +1,8 @@
 {
   "jcr:primaryType":"cq:ClientLibraryFolder",
   "categories":[
-    "wcm.io.authoring.dialog",
-    "cq.authoring.dialog"
+    "cq.authoring.dialog",
+    "cq.siteadmin.admin.properties"
   ],
   "dependencies":["granite.jquery"]
 }

--- a/media/src/main/webapp/app-root/clientlibs/authoring/dialog.json
+++ b/media/src/main/webapp/app-root/clientlibs/authoring/dialog.json
@@ -1,5 +1,8 @@
 {
   "jcr:primaryType":"cq:ClientLibraryFolder",
-  "categories":["cq.authoring.dialog"],
+  "categories":[
+    "wcm.io.authoring.dialog",
+    "cq.authoring.dialog"
+  ],
   "dependencies":["granite.jquery"]
 }

--- a/media/src/main/webapp/app-root/clientlibs/authoring/dialog.json
+++ b/media/src/main/webapp/app-root/clientlibs/authoring/dialog.json
@@ -1,8 +1,8 @@
 {
   "jcr:primaryType":"cq:ClientLibraryFolder",
   "categories":[
-    "wcm.io.authoring.dialog",
-    "cq.authoring.dialog"
+    "cq.authoring.dialog",
+    "cq.siteadmin.admin.properties"
   ],
   "dependencies":["granite.jquery"]
 }


### PR DESCRIPTION
Make it possible to load the client libs in different context, like page properties, without loading all cq.dialog.authoring client libs.