### PR TITLE
WHAN-49 Adds configuration to use host provided by Sling Mappings in Externalizer

### DIFF
--- a/url/changes.xml
+++ b/url/changes.xml
@@ -22,6 +22,11 @@
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/changes/1.0.0"
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
+    <release version="1.5.3">
+      <action type="add" dev="cnagel" issue="WHAN-49">
+        Add configuration to keep host from Sling Mappings.
+      </action>
+    </release>
 
     <release version="1.5.2" date="2021-03-25">
       <action type="update" dev="sseifert" issue="WTOOL-72">

--- a/url/changes.xml
+++ b/url/changes.xml
@@ -22,7 +22,8 @@
 <document xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/changes/1.0.0"
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
-    <release version="1.5.3">
+
+    <release version="1.6.0" date="not released">
       <action type="add" dev="cnagel" issue="WHAN-49">
         Add configuration to keep host from Sling Mappings.
       </action>

--- a/url/changes.xml
+++ b/url/changes.xml
@@ -25,7 +25,7 @@
 
     <release version="1.6.0" date="not released">
       <action type="add" dev="cnagel" issue="WHAN-49">
-        Add configuration to keep host from Sling Mappings.
+        Add new flag "isHostProvidedBySlingMapping" to UrlHandlerConfig which directs the URL handler to also respect host names that are configured in the Sling Mapping configuration for externalization.
       </action>
     </release>
 

--- a/url/src/main/java/io/wcm/handler/url/impl/Externalizer.java
+++ b/url/src/main/java/io/wcm/handler/url/impl/Externalizer.java
@@ -52,6 +52,23 @@ final class Externalizer {
    *         configured), and the path is URL-encoded if it contains special chars.
    */
   public static @Nullable String externalizeUrl(@NotNull String url, @NotNull ResourceResolver resolver, @Nullable SlingHttpServletRequest request) {
+    return externalizeUrlWithSlingMapping(url, resolver, request, false);
+  }
+
+  /**
+   * Externalizes a URL by applying Sling Mapping. Hostname and scheme will be added. URLs that are already externalized
+   * remain untouched.
+   * @param url non-externalized URL (without scheme or hostname)
+   * @param resolver Resource resolver
+   * @param request Request
+   * @return Externalized URL with scheme or hostname, short URLs (if configured in Sling Mapping),
+   *         and the path is URL-encoded if it contains special chars.
+   */
+  public static @Nullable String externalizeUrlWithHost(@NotNull String url, @NotNull ResourceResolver resolver, @Nullable SlingHttpServletRequest request) {
+    return externalizeUrlWithSlingMapping(url, resolver, request, true);
+  }
+
+  private static @Nullable String externalizeUrlWithSlingMapping(@NotNull String url, @NotNull ResourceResolver resolver, @Nullable SlingHttpServletRequest request, boolean keepHost) {
 
     // apply externalization only path part
     String path = url;
@@ -80,14 +97,15 @@ final class Externalizer {
       path = resolver.map(path);
     }
 
-    // remove scheme and hostname (probably added by sling mapping), but leave path in escaped form
-    try {
-      path = new URI(path).getRawPath();
-      // replace %2F back to / for better readability
-      path = StringUtils.replace(path, "%2F", "/");
-    }
-    catch (URISyntaxException ex) {
-      throw new RuntimeException("Sling map method returned invalid URI: " + path, ex);
+    if (!keepHost) {
+      // remove scheme and hostname (probably added by sling mapping), but leave path in escaped form
+      try {
+        path = new URI(path).getRawPath();
+        // replace %2F back to / for better readability
+        path = StringUtils.replace(path, "%2F", "/");
+      } catch (URISyntaxException ex) {
+        throw new RuntimeException("Sling map method returned invalid URI: " + path, ex);
+      }
     }
 
     // build full URL again

--- a/url/src/main/java/io/wcm/handler/url/impl/Externalizer.java
+++ b/url/src/main/java/io/wcm/handler/url/impl/Externalizer.java
@@ -68,7 +68,8 @@ final class Externalizer {
     return externalizeUrlWithSlingMapping(url, resolver, request, true);
   }
 
-  private static @Nullable String externalizeUrlWithSlingMapping(@NotNull String url, @NotNull ResourceResolver resolver, @Nullable SlingHttpServletRequest request, boolean keepHost) {
+  private static @Nullable String externalizeUrlWithSlingMapping(@NotNull String url, @NotNull ResourceResolver resolver,
+      @Nullable SlingHttpServletRequest request, boolean keepHost) {
 
     // apply externalization only path part
     String path = url;

--- a/url/src/main/java/io/wcm/handler/url/impl/UrlHandlerImpl.java
+++ b/url/src/main/java/io/wcm/handler/url/impl/UrlHandlerImpl.java
@@ -149,14 +149,19 @@ public final class UrlHandlerImpl implements UrlHandler {
       return url;
     }
 
-    // apply sling mapping, namespace mangling and add webapp context path if required
-    String externalizedUrl = Externalizer.externalizeUrl(url, resolver, request);
+    if (urlHandlerConfig.isHostProvidedBySlingMapping()) {
+      // apply sling mapping with host
+      return Externalizer.externalizeUrlWithHost(url, resolver, request);
+    } else {
+      // apply sling mapping, namespace mangling and add webapp context path if required
+      String externalizedUrl = Externalizer.externalizeUrl(url, resolver, request);
 
-    // add link URL prefix (scheme/hostname or integrator placeholder) if required
-    String linkUrlPrefix = getLinkUrlPrefix(urlMode, targetPage);
-    externalizedUrl = StringUtils.defaultString(linkUrlPrefix) + externalizedUrl; //NOPMD
+      // add link URL prefix (scheme/hostname or integrator placeholder) if required
+      String linkUrlPrefix = getLinkUrlPrefix(urlMode, targetPage);
+      externalizedUrl = StringUtils.defaultString(linkUrlPrefix) + externalizedUrl; //NOPMD
 
-    return externalizedUrl;
+      return externalizedUrl;
+    }
   }
 
   @SuppressWarnings("null")
@@ -187,14 +192,19 @@ public final class UrlHandlerImpl implements UrlHandler {
     // check for reference to static resource from proxied client library
     String externalizedUrl = clientlibProxyRewriter.rewriteStaticResourcePath(url);
 
-    // apply sling mapping when externalizing URLs
-    externalizedUrl = Externalizer.externalizeUrl(externalizedUrl, resolver, request);
+    if (urlHandlerConfig.isHostProvidedBySlingMapping()) {
+      // apply sling mapping with host
+      return Externalizer.externalizeUrlWithHost(externalizedUrl, resolver, request);
+    } else {
+      // apply sling mapping when externalizing URLs
+      externalizedUrl = Externalizer.externalizeUrl(externalizedUrl, resolver, request);
 
-    // add resource URL prefix (scheme/hostname or integrator placeholder) if required
-    String resourceUrlPrefix = getResourceUrlPrefix(urlMode, resource);
-    externalizedUrl = StringUtils.defaultString(resourceUrlPrefix) + externalizedUrl; //NOPMD
+      // add resource URL prefix (scheme/hostname or integrator placeholder) if required
+      String resourceUrlPrefix = getResourceUrlPrefix(urlMode, resource);
+      externalizedUrl = StringUtils.defaultString(resourceUrlPrefix) + externalizedUrl; //NOPMD
 
-    return externalizedUrl;
+      return externalizedUrl;
+    }
   }
 
   @SuppressWarnings("null")

--- a/url/src/main/java/io/wcm/handler/url/impl/UrlHandlerImpl.java
+++ b/url/src/main/java/io/wcm/handler/url/impl/UrlHandlerImpl.java
@@ -149,19 +149,21 @@ public final class UrlHandlerImpl implements UrlHandler {
       return url;
     }
 
+    String externalizedUrl;
     if (urlHandlerConfig.isHostProvidedBySlingMapping()) {
       // apply sling mapping with host
-      return Externalizer.externalizeUrlWithHost(url, resolver, request);
-    } else {
+      externalizedUrl = Externalizer.externalizeUrlWithHost(url, resolver, request);
+    }
+    else {
       // apply sling mapping, namespace mangling and add webapp context path if required
-      String externalizedUrl = Externalizer.externalizeUrl(url, resolver, request);
-
+      externalizedUrl = Externalizer.externalizeUrl(url, resolver, request);
+    }
+    if (externalizedUrl != null && !Externalizer.isExternalized(externalizedUrl)) {
       // add link URL prefix (scheme/hostname or integrator placeholder) if required
       String linkUrlPrefix = getLinkUrlPrefix(urlMode, targetPage);
       externalizedUrl = StringUtils.defaultString(linkUrlPrefix) + externalizedUrl; //NOPMD
-
-      return externalizedUrl;
     }
+    return externalizedUrl;
   }
 
   @SuppressWarnings("null")
@@ -194,17 +196,18 @@ public final class UrlHandlerImpl implements UrlHandler {
 
     if (urlHandlerConfig.isHostProvidedBySlingMapping()) {
       // apply sling mapping with host
-      return Externalizer.externalizeUrlWithHost(externalizedUrl, resolver, request);
-    } else {
+      externalizedUrl = Externalizer.externalizeUrlWithHost(externalizedUrl, resolver, request);
+    }
+    else {
       // apply sling mapping when externalizing URLs
       externalizedUrl = Externalizer.externalizeUrl(externalizedUrl, resolver, request);
-
+    }
+    if (externalizedUrl != null && !Externalizer.isExternalized(externalizedUrl)) {
       // add resource URL prefix (scheme/hostname or integrator placeholder) if required
       String resourceUrlPrefix = getResourceUrlPrefix(urlMode, resource);
       externalizedUrl = StringUtils.defaultString(resourceUrlPrefix) + externalizedUrl; //NOPMD
-
-      return externalizedUrl;
     }
+    return externalizedUrl;
   }
 
   @SuppressWarnings("null")

--- a/url/src/main/java/io/wcm/handler/url/package-info.java
+++ b/url/src/main/java/io/wcm/handler/url/package-info.java
@@ -20,5 +20,5 @@
 /**
  * URL Handler API.
  */
-@org.osgi.annotation.versioning.Version("1.1.1")
+@org.osgi.annotation.versioning.Version("1.1.2")
 package io.wcm.handler.url;

--- a/url/src/main/java/io/wcm/handler/url/spi/UrlHandlerConfig.java
+++ b/url/src/main/java/io/wcm/handler/url/spi/UrlHandlerConfig.java
@@ -84,8 +84,11 @@ public abstract class UrlHandlerConfig implements ContextAwareService {
   }
 
   /**
-   *
-   * @return True if externalizer uses host provided by Sling Mapping instead of UrlConfig.
+   * By default, URL handler users Sling Mapping to externalize all URLs, but removes and host name
+   * that may be configured in the Sling Mapping to prefer the host names defined in the URL handler
+   * {@link io.wcm.handler.url.SiteConfig}. By setting this flag to true, URL handler also uses
+   * the host names provided by Sling Mapping, and falls back to the default behavior if no are defined.
+   * @return true if URL handler should also respect host names defined in Sling Mapping
    */
   public boolean isHostProvidedBySlingMapping() {
     return false;

--- a/url/src/main/java/io/wcm/handler/url/spi/UrlHandlerConfig.java
+++ b/url/src/main/java/io/wcm/handler/url/spi/UrlHandlerConfig.java
@@ -83,4 +83,12 @@ public abstract class UrlHandlerConfig implements ContextAwareService {
     return ImmutableList.of();
   }
 
+  /**
+   *
+   * @return True if externalizer uses host provided by Sling Mapping instead of UrlConfig.
+   */
+  public boolean isHostProvidedBySlingMapping() {
+    return false;
+  }
+
 }

--- a/url/src/main/java/io/wcm/handler/url/spi/package-info.java
+++ b/url/src/main/java/io/wcm/handler/url/spi/package-info.java
@@ -20,5 +20,5 @@
 /**
  * SPI for configuring and tailoring URL handler processing.
  */
-@org.osgi.annotation.versioning.Version("1.0.1")
+@org.osgi.annotation.versioning.Version("1.1.0")
 package io.wcm.handler.url.spi;

--- a/url/src/site/markdown/general-concepts.md
+++ b/url/src/site/markdown/general-concepts.md
@@ -62,6 +62,8 @@ The URL handler can externalize URLs that point to AEM content pages or assets w
 
 Unlike the AEM [Externalizer][aem-externalizer] service the configuration of these domains is done via Sling Context-Aware configuration and thus fully supporting a multi-tenancy context.
 
+Alternatively, the domain names which are configured as part of the Sling Mapping configuration can be used for externalization. This has to be enabled explicitly in the UrlHandlerConfig.
+
 
 ### URL modes
 

--- a/url/src/test/java/io/wcm/handler/url/impl/ExternalizerTest.java
+++ b/url/src/test/java/io/wcm/handler/url/impl/ExternalizerTest.java
@@ -113,6 +113,28 @@ class ExternalizerTest {
   }
 
   @Test
+  void testExternalizeUrlWithHost() {
+
+    // use mocked resolver to mock sling mapping
+    ResourceResolver mockedResolver = mock(ResourceResolver.class);
+    when(mockedResolver.map(same(context.request()), anyString())).then(new Answer<String>() {
+      @Override
+      public String answer(InvocationOnMock invocation) {
+        return "http://www.domain.com/context" + (String)invocation.getArguments()[1];
+      }
+    });
+
+    assertExternalizeUrlWithHost("http://www.domain.com/context/the/path", "/the/path", mockedResolver);
+    assertExternalizeUrlWithHost("http://www.domain.com/context/the/path?param=1", "/the/path?param=1", mockedResolver);
+    assertExternalizeUrlWithHost("http://www.domain.com/context/the/path#hash", "/the/path#hash", mockedResolver);
+
+  }
+
+  private void assertExternalizeUrlWithHost(String expected, String url, ResourceResolver resolver) {
+    assertEquals(expected, Externalizer.externalizeUrlWithHost(url, resolver, context.request()));
+  }
+
+  @Test
   void testIsExternalized() {
     assertFalse(Externalizer.isExternalized("/absolute/path"));
     assertFalse(Externalizer.isExternalized("/ns:absolute/path"));

--- a/url/src/test/java/io/wcm/handler/url/impl/ExternalizerTest.java
+++ b/url/src/test/java/io/wcm/handler/url/impl/ExternalizerTest.java
@@ -127,11 +127,13 @@ class ExternalizerTest {
     assertExternalizeUrlWithHost("http://www.domain.com/context/the/path", "/the/path", mockedResolver);
     assertExternalizeUrlWithHost("http://www.domain.com/context/the/path?param=1", "/the/path?param=1", mockedResolver);
     assertExternalizeUrlWithHost("http://www.domain.com/context/the/path#hash", "/the/path#hash", mockedResolver);
-
   }
 
-  private void assertExternalizeUrlWithHost(String expected, String url, ResourceResolver resolver) {
-    assertEquals(expected, Externalizer.externalizeUrlWithHost(url, resolver, context.request()));
+  @Test
+  void testExternalizeUrlWithHostWithoutActualSlingMappingConfiguration() {
+    assertExternalizeUrlWithHost("/the/path", "/the/path", context.resourceResolver());
+    assertExternalizeUrlWithHost("/the/path?param=1", "/the/path?param=1", context.resourceResolver());
+    assertExternalizeUrlWithHost("/the/path#hash", "/the/path#hash", context.resourceResolver());
   }
 
   @Test
@@ -165,6 +167,10 @@ class ExternalizerTest {
     assertFalse(Externalizer.isExternalizable(""));
     assertFalse(Externalizer.isExternalizable("abc"));
     assertTrue(Externalizer.isExternalizable("/abc"));
+  }
+
+  private void assertExternalizeUrlWithHost(String expected, String url, ResourceResolver resolver) {
+    assertEquals(expected, Externalizer.externalizeUrlWithHost(url, resolver, context.request()));
   }
 
 }

--- a/url/src/test/java/io/wcm/handler/url/impl/UrlHandlerImplTest.java
+++ b/url/src/test/java/io/wcm/handler/url/impl/UrlHandlerImplTest.java
@@ -33,8 +33,6 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Set;
 
-import io.wcm.handler.url.spi.UrlHandlerConfig;
-import io.wcm.handler.url.testcontext.DummyUrlHandlerConfig;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.adapter.Adaptable;
@@ -46,7 +44,6 @@ import org.apache.sling.servlethelpers.MockSlingHttpServletRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -57,8 +54,10 @@ import io.wcm.handler.url.UrlHandler;
 import io.wcm.handler.url.UrlMode;
 import io.wcm.handler.url.UrlModes;
 import io.wcm.handler.url.integrator.IntegratorPlaceholder;
+import io.wcm.handler.url.spi.UrlHandlerConfig;
 import io.wcm.handler.url.testcontext.AppAemContext;
 import io.wcm.handler.url.testcontext.DummyAppTemplate;
+import io.wcm.handler.url.testcontext.DummyUrlHandlerConfig;
 import io.wcm.sling.commons.adapter.AdaptTo;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
@@ -406,7 +405,7 @@ class UrlHandlerImplTest {
             DummyAppTemplate.CONTENT.getTemplatePath());
 
     // set config flag
-    ((DummyUrlHandlerConfig) context.getService(UrlHandlerConfig.class)).setHostProvidedBySlingMapping(true);
+    ((DummyUrlHandlerConfig)context.getService(UrlHandlerConfig.class)).setHostProvidedBySlingMapping(true);
 
     // mock request and resolver
     ResourceResolver spyResolver = spy(context.request().getResourceResolver());
@@ -528,11 +527,11 @@ class UrlHandlerImplTest {
   @Test
   void testExternalizeResourceUrlHostBySlingMapping() {
     // create more pages to simulate internal link
-    Page targetPage = context.create().page("/content/unittest/de_test/brand/de/section2/page2a",
+    context.create().page("/content/unittest/de_test/brand/de/section2/page2a",
             DummyAppTemplate.CONTENT.getTemplatePath());
 
     // set config flag
-    ((DummyUrlHandlerConfig) context.getService(UrlHandlerConfig.class)).setHostProvidedBySlingMapping(true);
+    ((DummyUrlHandlerConfig)context.getService(UrlHandlerConfig.class)).setHostProvidedBySlingMapping(true);
 
     // mock request and resolver
     ResourceResolver spyResolver = spy(context.request().getResourceResolver());

--- a/url/src/test/java/io/wcm/handler/url/testcontext/DummyUrlHandlerConfig.java
+++ b/url/src/test/java/io/wcm/handler/url/testcontext/DummyUrlHandlerConfig.java
@@ -43,9 +43,9 @@ public class DummyUrlHandlerConfig extends UrlHandlerConfig {
   private static final List<IntegratorMode> INTEGRATOR_MODES = ImmutableList.<IntegratorMode>of(
       IntegratorModes.SIMPLE,
       IntegratorModes.EXTENDED
-      );
+  );
 
-  private boolean hostProvidedBySlingMapping = false;
+  private boolean hostProvidedBySlingMapping;
 
   @Override
   public List<IntegratorMode> getIntegratorModes() {

--- a/url/src/test/java/io/wcm/handler/url/testcontext/DummyUrlHandlerConfig.java
+++ b/url/src/test/java/io/wcm/handler/url/testcontext/DummyUrlHandlerConfig.java
@@ -45,6 +45,8 @@ public class DummyUrlHandlerConfig extends UrlHandlerConfig {
       IntegratorModes.EXTENDED
       );
 
+  private boolean hostProvidedBySlingMapping = false;
+
   @Override
   public List<IntegratorMode> getIntegratorModes() {
     return INTEGRATOR_MODES;
@@ -65,6 +67,15 @@ public class DummyUrlHandlerConfig extends UrlHandlerConfig {
   @Override
   public int getSiteRootLevel(Resource contextResource) {
     return SITE_ROOT_LEVEL;
+  }
+
+  @Override
+  public boolean isHostProvidedBySlingMapping() {
+    return hostProvidedBySlingMapping;
+  }
+
+  public void setHostProvidedBySlingMapping(boolean hostProvidedBySlingMapping) {
+    this.hostProvidedBySlingMapping = hostProvidedBySlingMapping;
   }
 
 }


### PR DESCRIPTION
Sling Mappings can contain host information. This gets lost in the UrlHandler when externalizing a URL.
This task extends the UrlHandlerConfig to keep the host provided by Sling Mapping.