### PR TITLE
Possible preprocessing of raw richtext before the xml parsing

### DIFF
--- a/richtext/src/main/java/io/wcm/handler/richtext/spi/RichTextHandlerConfig.java
+++ b/richtext/src/main/java/io/wcm/handler/richtext/spi/RichTextHandlerConfig.java
@@ -19,6 +19,7 @@
  */
 package io.wcm.handler.richtext.spi;
 
+import java.util.Collections;
 import java.util.List;
 
 import org.jetbrains.annotations.NotNull;
@@ -28,6 +29,7 @@ import com.google.common.collect.ImmutableList;
 
 import io.wcm.handler.richtext.DefaultRewriteContentHandler;
 import io.wcm.handler.richtext.util.RewriteContentHandler;
+import io.wcm.handler.richtext.util.RewriteRawTextHandler;
 import io.wcm.sling.commons.caservice.ContextAwareService;
 
 /**
@@ -48,6 +50,15 @@ public abstract class RichTextHandlerConfig implements ContextAwareService {
    */
   public @NotNull List<Class<? extends RewriteContentHandler>> getRewriteContentHandlers() {
     return DEFAULT_REWRITE_CONTENT_HANDLERS;
+  }
+
+  /**
+   * Defines a list of rewrite raw text handlers. If multiple implementations are provided, all
+   * are called on after another on the text of the richtext request.
+   * @return Available rewrite raw text handler
+   */
+  public @NotNull List<Class<? extends RewriteRawTextHandler>> getRewriteRawTextHandlers() {
+    return Collections.emptyList();
   }
 
 }

--- a/richtext/src/main/java/io/wcm/handler/richtext/spi/package-info.java
+++ b/richtext/src/main/java/io/wcm/handler/richtext/spi/package-info.java
@@ -20,5 +20,5 @@
 /**
  * SPI for configuring and tailoring rich text handler processing.
  */
-@org.osgi.annotation.versioning.Version("1.0.1")
+@org.osgi.annotation.versioning.Version("1.1.0")
 package io.wcm.handler.richtext.spi;

--- a/richtext/src/main/java/io/wcm/handler/richtext/util/RewriteRawTextHandler.java
+++ b/richtext/src/main/java/io/wcm/handler/richtext/util/RewriteRawTextHandler.java
@@ -1,0 +1,46 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2021 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.handler.richtext.util;
+
+import org.osgi.annotation.versioning.ConsumerType;
+
+import com.drew.lang.annotations.Nullable;
+
+import io.wcm.handler.richtext.RichTextHandler;
+import io.wcm.handler.richtext.RichTextRequest;
+
+/**
+ * Allows to modify the raw text of the {@link RichTextRequest} before it is processed in the {@link RichTextHandler}.
+ * <p>
+ * If used for {@link io.wcm.handler.richtext.spi.RichTextHandlerConfig} this interface has to be
+ * implemented by a Sling Model class. The adaptables should be
+ * {@link org.apache.sling.api.SlingHttpServletRequest} and {@link org.apache.sling.api.resource.Resource}.
+ * </p>
+ */
+@ConsumerType
+public interface RewriteRawTextHandler {
+
+  /**
+   * @param text The text that should rewrite by this handler.
+   * @return The rewritten text.
+   */
+  @Nullable
+  String rewriteText(@Nullable String text);
+}

--- a/richtext/src/main/java/io/wcm/handler/richtext/util/package-info.java
+++ b/richtext/src/main/java/io/wcm/handler/richtext/util/package-info.java
@@ -20,5 +20,5 @@
 /**
  * Helper classes for RichText handling.
  */
-@org.osgi.annotation.versioning.Version("1.0.1")
+@org.osgi.annotation.versioning.Version("1.1.0")
 package io.wcm.handler.richtext.util;


### PR DESCRIPTION
RichTextHandlerConfig can return handlers, that can preprocess the richtext of the richtext request before the dom model is parsed.  This makes it possible to remove illegal characters from the text without overloading the models of the components, that displays the richtext.